### PR TITLE
Parse command and logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tooga-booga",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A simple Discord bot for Realm of the Mad God servers, designed for verification and raid management. ",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tooga-booga",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A simple Discord bot for Realm of the Mad God servers, designed for verification and raid management. ",
   "main": "index.js",
   "scripts": {

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -141,6 +141,7 @@ export class Bot {
             new Cmds.RemoveName(),
             new Cmds.ParseRaidVc(),
             new Cmds.YoinkVC(),
+            new Cmds.ClearVC(),
             new Cmds.Poll(),
             new Cmds.Purge()
         ]);

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -141,7 +141,7 @@ export class Bot {
             new Cmds.RemoveName(),
             new Cmds.ParseRaidVc(),
             new Cmds.YoinkVC(),
-            new Cmds.ClearVC(),
+            new Cmds.CleanVC(),
             new Cmds.Poll(),
             new Cmds.Purge()
         ]);

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -25,9 +25,9 @@ import {REST} from "@discordjs/rest";
 import {RESTPostAPIApplicationCommandsJSONBody, Routes} from "discord-api-types/v9";
 import {Logger} from "./utilities/Logger";
 
-export class Bot {
+const LOGGER: Logger = new Logger(__filename, false);
 
-    private _logger: Logger;
+export class Bot {
 
     private readonly _config: IConfiguration;
     private readonly _bot: Client;
@@ -80,10 +80,9 @@ export class Bot {
      * @throws {Error} If a command name was registered twice or if `data.name` is not equal to `botCommandName`.
      */
     public constructor(config: IConfiguration | null) {
-        this._logger = new Logger(__filename, false);
 
         if (!config) {
-            this._logger.error("No config file given.");
+            LOGGER.error("No config file given.");
             throw new Error("No config file given.");
         }
 
@@ -112,9 +111,9 @@ export class Bot {
             ]
         });
         Bot.BotInstance = this;
-        this._logger.info(`Starting Bot`);
+        LOGGER.info(`Starting Bot`);
 
-        this._logger.info(`Configuring commands`);
+        LOGGER.info(`Configuring commands`);
         Bot.Commands = new Collection<string, Cmds.BaseCommand[]>();
 
         Bot.Commands.set("Bot Information", [
@@ -233,7 +232,7 @@ export class Bot {
         if (this._eventsIsStarted)
             return;
 
-        this._logger.info("Starting all events");
+        LOGGER.info("Starting all events");
 
         this._bot.on("ready", async () => onReadyEvent());
         this._bot.on("interactionCreate", async (i: Interaction) => onInteractionEvent(i));
@@ -256,7 +255,7 @@ export class Bot {
             this.startAllEvents();
 
         // connects to the database
-        this._logger.info("Connecting bot to database");
+        LOGGER.info("Connecting bot to database");
         await MongoManager.connect({
             dbUrl: this._config.database.connectionString,
             dbName: this._config.database.dbName,
@@ -268,7 +267,7 @@ export class Bot {
         });
 
         // logs into the bot
-        this._logger.info("Logging in bot");
+        LOGGER.info("Logging in bot");
         await this._bot.login(this._config.tokens.botToken);
     }
 
@@ -279,7 +278,7 @@ export class Bot {
      */
     public initServices(): boolean {
         // MuteManager + SuspensionManager started in ready event.
-        this._logger.info("Starting Quota Service");
+        LOGGER.info("Starting Quota Service");
         QuotaService.startService().then();
         return true;
     }

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -170,6 +170,7 @@ export class Bot {
         Bot.Commands.set("Logging", [
             new Cmds.LogLedRun(),
             new Cmds.LogKeyPop(),
+            new Cmds.LogParse(),
             new Cmds.GivePoints()
         ]);
 

--- a/src/commands/bot/BotInfo.ts
+++ b/src/commands/bot/BotInfo.ts
@@ -45,7 +45,7 @@ export class BotInfo extends BaseCommand {
             .addField(
                 "Uptime",
                 StringUtil.codifyString(
-                    TimeUtilities.formatDuration(Date.now() - instance.instanceStarted.getTime(), false)
+                    TimeUtilities.formatDuration(Date.now() - instance.instanceStarted.getTime(), true, false)
                 ), true
             )
             .addField("Bot Developer(s)", botOwners.map(x => `${x} (${x!.tag})`).join("\n"))

--- a/src/commands/config/ConfigureAfkCheck.ts
+++ b/src/commands/config/ConfigureAfkCheck.ts
@@ -248,7 +248,7 @@ export class ConfigureAfkCheck extends BaseCommand {
                 )
                 .addField(
                     "AFK Check Expiration Time",
-                    StringUtil.codifyString(TimeUtilities.formatDuration(newAfkCheckProps.afkCheckTimeout, false)),
+                    StringUtil.codifyString(TimeUtilities.formatDuration(newAfkCheckProps.afkCheckTimeout, true, false)),
                     true
                 )
                 .addField(
@@ -523,7 +523,7 @@ export class ConfigureAfkCheck extends BaseCommand {
                                         + " you can set is 5 minutes and the highest is 2 hours. After the time is"
                                         + " gone, the AFK check will automatically end. The current time is set to:"
                                         + StringUtil.codifyString(
-                                            TimeUtilities.formatDuration(newAfkCheckProps.afkCheckTimeout, false)
+                                            TimeUtilities.formatDuration(newAfkCheckProps.afkCheckTimeout, true, false)
                                         )
                                         + "Please type the duration now. Supported time units are minutes (m) or hours"
                                         + " (h). For example, to specify 1 hour and 10 minutes, use \"1h10m\" as the"

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -22,6 +22,7 @@ export * from "./staff/AddOrChangeName";
 export * from "./staff/RemoveName";
 export * from "./staff/ParseRaidVc";
 export * from "./staff/YoinkVC";
+export * from "./staff/ClearVC";
 export * from "./staff/Poll";
 export * from "./staff/Purge";
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -37,6 +37,7 @@ export * from "./punishments/UnsuspendFromSection";
 
 export * from "./logging/LogLedRun";
 export * from "./logging/LogKeyPop";
+export * from "./logging/LogParse";
 export * from "./logging/GivePoints";
 
 export * from "./owner/SendAnnouncement";

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -22,7 +22,7 @@ export * from "./staff/AddOrChangeName";
 export * from "./staff/RemoveName";
 export * from "./staff/ParseRaidVc";
 export * from "./staff/YoinkVC";
-export * from "./staff/ClearVC";
+export * from "./staff/CleanVC";
 export * from "./staff/Poll";
 export * from "./staff/Purge";
 

--- a/src/commands/logging/LogKeyPop.ts
+++ b/src/commands/logging/LogKeyPop.ts
@@ -126,7 +126,7 @@ export class LogKeyPop extends BaseCommand {
             components: AdvancedCollector.getActionRowsFromComponents([
                 ...selectMenus,
                 AdvancedCollector.cloneButton(ButtonConstants.CANCEL_BUTTON)
-                    .setCustomId(uniqueId + "_CANCEL")
+                    .setCustomId(uniqueId + ButtonConstants.CANCEL_ID)
             ])
         });
 

--- a/src/commands/logging/LogLedRun.ts
+++ b/src/commands/logging/LogLedRun.ts
@@ -189,7 +189,8 @@ export class LogLedRun extends BaseCommand {
             ],
             components: AdvancedCollector.getActionRowsFromComponents([
                 ...selectMenus,
-                ButtonConstants.CANCEL_BUTTON
+                AdvancedCollector.cloneButton(ButtonConstants.CANCEL_BUTTON)
+                    .setCustomId(uniqueId + ButtonConstants.CANCEL_ID)
             ])
         });
 

--- a/src/commands/logging/LogParse.ts
+++ b/src/commands/logging/LogParse.ts
@@ -9,9 +9,8 @@ import {QuotaManager} from "../../managers/QuotaManager";
 import {ButtonConstants} from "../../constants/ButtonConstants";
 import {Logger} from "../../utilities/Logger";
 
+const LOGGER: Logger = new Logger(__filename, false);
 export class LogParse extends BaseCommand{
-
-    private _logger : Logger;
 
     public constructor() {
         const cmi: ICommandInfo = {
@@ -51,8 +50,6 @@ export class LogParse extends BaseCommand{
             botOwnerOnly: false
         };
         super(cmi);        
-
-        this._logger = new Logger(__filename);
     }
 
     /**
@@ -86,7 +83,7 @@ export class LogParse extends BaseCommand{
 
         const cInt = ctx.interaction.options.getInteger("completed", false) ?? 1;
 
-        this._logger.info("Logging " + cInt + " parses for " + memberToLogAs.displayName + "...");
+        LOGGER.info("Logging " + cInt + " parses for " + memberToLogAs.displayName + "...");
 
         const uniqueId = StringUtil.generateRandomString(20);
         await ctx.interaction.reply({
@@ -125,7 +122,7 @@ export class LogParse extends BaseCommand{
         }, uniqueId);
 
         if (!selection || selection.customId === uniqueId+ButtonConstants.CANCEL_ID){
-            this._logger.info("Logparse cancelled for " + memberToLogAs.displayName);
+            LOGGER.info("Logparse cancelled for " + memberToLogAs.displayName);
             await ctx.interaction.editReply({
                 components: [],
                 content: "You cancelled the logging process.",
@@ -148,7 +145,7 @@ export class LogParse extends BaseCommand{
             embeds: []
         });
 
-        this._logger.info("Logparse completed for " + memberToLogAs.displayName);
+        LOGGER.info("Logparse completed for " + memberToLogAs.displayName);
         return 0;
     }
 }

--- a/src/commands/logging/LogParse.ts
+++ b/src/commands/logging/LogParse.ts
@@ -1,0 +1,160 @@
+import {ArgumentType, BaseCommand, ICommandContext, ICommandInfo} from "../BaseCommand";
+import {GuildFgrUtilities} from "../../utilities/fetch-get-request/GuildFgrUtilities";
+import {UserManager} from "../../managers/UserManager";
+import {MongoManager} from "../../managers/MongoManager";
+import {MessageSelectMenu} from "discord.js";
+import {DUNGEON_DATA} from "../../constants/dungeons/DungeonData";
+import {ArrayUtilities} from "../../utilities/ArrayUtilities";
+import {StringUtil} from "../../utilities/StringUtilities";
+import {AdvancedCollector} from "../../utilities/collectors/AdvancedCollector";
+import {MessageUtilities} from "../../utilities/MessageUtilities";
+import {StringBuilder} from "../../utilities/StringBuilder";
+import {LoggerManager} from "../../managers/LoggerManager";
+import {QuotaManager} from "../../managers/QuotaManager";
+import {QuotaLogType} from "../../definitions/Types";
+import {ButtonConstants} from "../../constants/ButtonConstants";
+import {Logger} from "../../utilities/Logger";
+
+export class LogParse extends BaseCommand{
+
+    private logger : Logger;
+
+    public constructor() {
+        const cmi: ICommandInfo = {
+            cmdCode: "LOG_PARSE_COMMAND",
+            formalCommandName: "Log Parse(s) Command",
+            botCommandName: "logparse",
+            description: "Logs one or more parses that a staff performed.",
+            commandCooldown: 0,
+            generalPermissions: [],
+            argumentInfo: [
+                {
+                    displayName: "Member",
+                    argName: "member",
+                    desc: "The member to log a parse for. If no member is specified, this will log for you.",
+                    type: ArgumentType.String,
+                    prettyType: "Member Resolvable (ID, Mention, IGN)",
+                    required: false,
+                    example: ["@Console#8939", "123313141413155", "Darkmattr"]
+                },
+                {
+                    displayName: "Completed Parses",
+                    argName: "completed",
+                    desc: "The number of completed parses.  If not provided, defaults to 1.",
+                    type: ArgumentType.Integer,
+                    prettyType: "Integer",
+                    required: false,
+                    example: ["5"]
+                },
+            ],
+            botPermissions: [],
+            rolePermissions: [
+                "Helper",
+                "Officer",
+                "Moderator"
+            ],
+            guildOnly: true,
+            botOwnerOnly: false
+        };
+        super(cmi);        
+
+        this.logger = new Logger(require('path').basename(__filename));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public async run(ctx: ICommandContext): Promise<number> {
+        
+        const mStr = ctx.interaction.options.getString("member", false);
+
+        let memberToLogAs = ctx.member!;
+        // See if there is another member to log as. We also need to make sure
+        // there is a database entry available
+        const resMember = mStr
+            ? await UserManager.resolveMember(ctx.guild!, mStr)
+            : null;
+        if (resMember) {
+            if (!resMember.idNameDoc) {
+                await MongoManager.addIdNameToIdNameCollection(resMember.member);
+            }
+
+            if (!resMember.userDoc) {
+                await MongoManager.getOrCreateUserDoc(resMember.member.id);
+            }
+
+            memberToLogAs = resMember.member;
+        }
+        else {
+            await MongoManager.addIdNameToIdNameCollection(memberToLogAs);
+            await MongoManager.getOrCreateUserDoc(memberToLogAs.id);
+        }
+
+        const cInt = ctx.interaction.options.getInteger("completed", false) ?? 1;
+
+        this.logger.info("Logging " + cInt + " parses for " + memberToLogAs.displayName + "...");
+
+        const uniqueId = StringUtil.generateRandomString(20);
+        await ctx.interaction.reply({
+            embeds: [
+                MessageUtilities.generateBlankEmbed(ctx.guild!, "RED")
+                    .setTitle("Manually Logging Parses")
+                    .setDescription(
+                        new StringBuilder()
+                            .append("You are logging the following parses for ")
+                            .append(memberToLogAs.id === ctx.user.id ? "yourself" : memberToLogAs.toString())
+                            .append(":").appendLine()
+                            .append(`- \`${cInt}\` Parses.`).appendLine()
+                            .toString()
+                    )
+                    .addField(
+                        "Confirmation",
+                        "If the above is correct, please select **Continue**.  Otherwise, "
+                        + "press the **Cancel** button and re-run this"
+                        + " command with the proper values."
+                    )
+            ],
+            components: AdvancedCollector.getActionRowsFromComponents([
+                AdvancedCollector.cloneButton(ButtonConstants.CONTINUE_BUTTON)
+                    .setCustomId(uniqueId + ButtonConstants.CONTINUE_ID),
+                AdvancedCollector.cloneButton(ButtonConstants.CANCEL_BUTTON)
+                    .setCustomId(uniqueId + ButtonConstants.CANCEL_ID)
+            ])
+        });
+
+
+        const selection = await AdvancedCollector.startInteractionEphemeralCollector({
+            targetAuthor: ctx.user,
+            acknowledgeImmediately: false,
+            targetChannel: ctx.channel,
+            duration: 1.5 * 60 * 1000
+        }, uniqueId);
+
+        if (!selection || selection.customId === uniqueId+ButtonConstants.CANCEL_ID){
+            this.logger.info("Logparse cancelled for " + memberToLogAs.displayName);
+            await ctx.interaction.editReply({
+                components: [],
+                content: "You cancelled the logging process.",
+                embeds: []
+            });
+            return 0;
+        }   
+        
+        const roleId = QuotaManager.findBestQuotaToAdd(memberToLogAs, ctx.guildDoc!, "Parse");
+        if (roleId) {
+            await QuotaManager.logQuota(memberToLogAs!, roleId, "Parse", cInt);
+        }
+
+        await ctx.interaction.editReply({
+            components: [],
+            content: new StringBuilder()
+                .append(`Logging completed! As a reminder, you logged \`${cInt}\``)
+                .append("parses for ").append(memberToLogAs.id === ctx.user.id ? "yourself" : memberToLogAs.toString())
+                .toString(),
+            embeds: []
+        });
+
+        this.logger.info("Logparse completed for " + memberToLogAs.displayName);
+        return 0;
+    }
+}

--- a/src/commands/logging/LogParse.ts
+++ b/src/commands/logging/LogParse.ts
@@ -1,23 +1,17 @@
 import {ArgumentType, BaseCommand, ICommandContext, ICommandInfo} from "../BaseCommand";
-import {GuildFgrUtilities} from "../../utilities/fetch-get-request/GuildFgrUtilities";
 import {UserManager} from "../../managers/UserManager";
 import {MongoManager} from "../../managers/MongoManager";
-import {MessageSelectMenu} from "discord.js";
-import {DUNGEON_DATA} from "../../constants/dungeons/DungeonData";
-import {ArrayUtilities} from "../../utilities/ArrayUtilities";
 import {StringUtil} from "../../utilities/StringUtilities";
 import {AdvancedCollector} from "../../utilities/collectors/AdvancedCollector";
 import {MessageUtilities} from "../../utilities/MessageUtilities";
 import {StringBuilder} from "../../utilities/StringBuilder";
-import {LoggerManager} from "../../managers/LoggerManager";
 import {QuotaManager} from "../../managers/QuotaManager";
-import {QuotaLogType} from "../../definitions/Types";
 import {ButtonConstants} from "../../constants/ButtonConstants";
 import {Logger} from "../../utilities/Logger";
 
 export class LogParse extends BaseCommand{
 
-    private logger : Logger;
+    private _logger : Logger;
 
     public constructor() {
         const cmi: ICommandInfo = {
@@ -58,7 +52,7 @@ export class LogParse extends BaseCommand{
         };
         super(cmi);        
 
-        this.logger = new Logger(require('path').basename(__filename));
+        this._logger = new Logger(__filename);
     }
 
     /**
@@ -92,7 +86,7 @@ export class LogParse extends BaseCommand{
 
         const cInt = ctx.interaction.options.getInteger("completed", false) ?? 1;
 
-        this.logger.info("Logging " + cInt + " parses for " + memberToLogAs.displayName + "...");
+        this._logger.info("Logging " + cInt + " parses for " + memberToLogAs.displayName + "...");
 
         const uniqueId = StringUtil.generateRandomString(20);
         await ctx.interaction.reply({
@@ -131,7 +125,7 @@ export class LogParse extends BaseCommand{
         }, uniqueId);
 
         if (!selection || selection.customId === uniqueId+ButtonConstants.CANCEL_ID){
-            this.logger.info("Logparse cancelled for " + memberToLogAs.displayName);
+            this._logger.info("Logparse cancelled for " + memberToLogAs.displayName);
             await ctx.interaction.editReply({
                 components: [],
                 content: "You cancelled the logging process.",
@@ -154,7 +148,7 @@ export class LogParse extends BaseCommand{
             embeds: []
         });
 
-        this.logger.info("Logparse completed for " + memberToLogAs.displayName);
+        this._logger.info("Logparse completed for " + memberToLogAs.displayName);
         return 0;
     }
 }

--- a/src/commands/moderator/ForceSync.ts
+++ b/src/commands/moderator/ForceSync.ts
@@ -223,7 +223,7 @@ export class ForceSync extends BaseCommand {
                     .addField("Skipped", StringUtil.codifyString(skipped), true)
                     .addField("Status", StringUtil.codifyString("Completed!"))
                     .addField("Time Taken", StringUtil.codifyString(
-                        TimeUtilities.formatDuration(Date.now() - timeStart, false))
+                        TimeUtilities.formatDuration(Date.now() - timeStart, true, false))
                     )
                     .setFooter({
                         text: `${namesUsed.size} names & ${ttlDocs} entries originally in database.`

--- a/src/commands/punishments/MuteMember.ts
+++ b/src/commands/punishments/MuteMember.ts
@@ -7,8 +7,10 @@ import {TimeUtilities} from "../../utilities/TimeUtilities";
 import {StringBuilder} from "../../utilities/StringBuilder";
 import generateRandomString = StringUtil.generateRandomString;
 import {preCheckPunishment} from "./common/PunishmentCommon";
+import {Logger} from "../../utilities/Logger"
 
 export class MuteMember extends BaseCommand {
+    private readonly _logger: Logger = new Logger(__filename);
     public static readonly ERROR_NO_MUTE_STR: string = new StringBuilder()
         .append("Something went wrong when trying to mute this person.").appendLine()
         .append("- The person already has the muted role. In this case, manually remove the Muted role and")
@@ -47,11 +49,11 @@ export class MuteMember extends BaseCommand {
                     displayName: "Duration",
                     argName: "duration",
                     desc: "The duration. Supported time units are minutes (m), hours (h), days (d), weeks (w). For"
-                        + " example, to specify 3 days, use \"3d\" as the duration. Not specifying a duration at all"
+                        + " example, to specify 3 days, use \"3d\" as the duration. Duration of -1"
                         + " implies an indefinite mute. Not specifying the time unit for the mute implies days.",
                     type: ArgumentType.String,
                     prettyType: "String",
-                    required: false,
+                    required: true,
                     example: ["3h10m", "10w10h8d-1m"]
                 },
                 {
@@ -85,7 +87,11 @@ export class MuteMember extends BaseCommand {
 
         const muteId = `Mute_${Date.now()}_${generateRandomString(15)}`;
 
-        const durationStr = ctx.interaction.options.getString("duration", false);
+        let durationStr = ctx.interaction.options.getString("duration", false);
+        if(durationStr === "-1") durationStr = null;
+        
+        this._logger.info(`Issuing mute for ${resMember?.member.displayName} of duration ${durationStr}`);
+
         const parsedDuration = durationStr ? TimeUtilities.parseTimeUnit(durationStr) : null;
 
         const reason = ctx.interaction.options.getString("reason", true);

--- a/src/commands/punishments/MuteMember.ts
+++ b/src/commands/punishments/MuteMember.ts
@@ -9,8 +9,8 @@ import generateRandomString = StringUtil.generateRandomString;
 import {preCheckPunishment} from "./common/PunishmentCommon";
 import {Logger} from "../../utilities/Logger"
 
+const LOGGER: Logger = new Logger(__filename, false);
 export class MuteMember extends BaseCommand {
-    private readonly _logger: Logger = new Logger(__filename);
     public static readonly ERROR_NO_MUTE_STR: string = new StringBuilder()
         .append("Something went wrong when trying to mute this person.").appendLine()
         .append("- The person already has the muted role. In this case, manually remove the Muted role and")
@@ -90,7 +90,7 @@ export class MuteMember extends BaseCommand {
         let durationStr = ctx.interaction.options.getString("duration", false);
         if(durationStr === "-1") durationStr = null;
         
-        this._logger.info(`Issuing mute for ${resMember?.member.displayName} of duration ${durationStr}`);
+        LOGGER.info(`Issuing mute for ${resMember?.member.displayName} of duration ${durationStr}`);
 
         const parsedDuration = durationStr ? TimeUtilities.parseTimeUnit(durationStr) : null;
 

--- a/src/commands/punishments/SectionSuspendMember.ts
+++ b/src/commands/punishments/SectionSuspendMember.ts
@@ -11,8 +11,10 @@ import {AdvancedCollector} from "../../utilities/collectors/AdvancedCollector";
 import {SuspendMember} from "./SuspendMember";
 import {preCheckPunishment} from "./common/PunishmentCommon";
 import {GlobalFgrUtilities} from "../../utilities/fetch-get-request/GlobalFgrUtilities";
+import {Logger} from "../../utilities/Logger"
 
 export class SectionSuspendMember extends BaseCommand {
+    private readonly _logger: Logger = new Logger(__filename);
     private static readonly ERROR_NO_SUSPEND_STR: string = new StringBuilder()
         .append("Something went wrong when trying to suspend this person.").appendLine()
         .append("- The person already has the suspended role. In this case, manually remove the Suspended role and")
@@ -43,11 +45,11 @@ export class SectionSuspendMember extends BaseCommand {
                     displayName: "Duration",
                     argName: "duration",
                     desc: "The duration. Supported time units are minutes (m), hours (h), days (d), weeks (w). For"
-                        + " example, to specify 3 days, use \"3d\" as the duration. Not specifying a duration at all"
+                        + " example, to specify 3 days, use \"3d\" as the duration. Duration of -1"
                         + " implies an indefinite suspension. Not specifying the time unit implies days.",
                     type: ArgumentType.String,
                     prettyType: "String",
-                    required: false,
+                    required: true,
                     example: ["3h10m", "10w10h8d-1m"]
                 },
                 {
@@ -141,7 +143,11 @@ export class SectionSuspendMember extends BaseCommand {
 
         const sectionPicked = sections.find(x => x.uniqueIdentifier === result.values[0])!;
 
-        const durationStr = ctx.interaction.options.getString("duration", false);
+        let durationStr = ctx.interaction.options.getString("duration", false);
+        if(durationStr === "-1") durationStr = null;
+        
+        this._logger.info(`Issuing mute for ${resMember?.member.displayName} of duration ${durationStr}`);
+
         const parsedDuration = durationStr ? TimeUtilities.parseTimeUnit(durationStr) : null;
 
         const reason = ctx.interaction.options.getString("reason", true);

--- a/src/commands/punishments/SectionSuspendMember.ts
+++ b/src/commands/punishments/SectionSuspendMember.ts
@@ -13,8 +13,8 @@ import {preCheckPunishment} from "./common/PunishmentCommon";
 import {GlobalFgrUtilities} from "../../utilities/fetch-get-request/GlobalFgrUtilities";
 import {Logger} from "../../utilities/Logger"
 
+const LOGGER: Logger = new Logger(__filename, false);
 export class SectionSuspendMember extends BaseCommand {
-    private readonly _logger: Logger = new Logger(__filename);
     private static readonly ERROR_NO_SUSPEND_STR: string = new StringBuilder()
         .append("Something went wrong when trying to suspend this person.").appendLine()
         .append("- The person already has the suspended role. In this case, manually remove the Suspended role and")
@@ -146,7 +146,7 @@ export class SectionSuspendMember extends BaseCommand {
         let durationStr = ctx.interaction.options.getString("duration", false);
         if(durationStr === "-1") durationStr = null;
         
-        this._logger.info(`Issuing mute for ${resMember?.member.displayName} of duration ${durationStr}`);
+        LOGGER.info(`Issuing mute for ${resMember?.member.displayName} of duration ${durationStr}`);
 
         const parsedDuration = durationStr ? TimeUtilities.parseTimeUnit(durationStr) : null;
 

--- a/src/commands/punishments/SuspendMember.ts
+++ b/src/commands/punishments/SuspendMember.ts
@@ -7,8 +7,10 @@ import {MessageUtilities} from "../../utilities/MessageUtilities";
 import {StringUtil} from "../../utilities/StringUtilities";
 import {preCheckPunishment} from "./common/PunishmentCommon";
 import {GlobalFgrUtilities} from "../../utilities/fetch-get-request/GlobalFgrUtilities";
+import {Logger} from "../../utilities/Logger"
 
 export class SuspendMember extends BaseCommand {
+    private readonly _logger: Logger = new Logger(__filename);
     public static readonly ERROR_NO_SUSPEND_STR: string = new StringBuilder()
         .append("Something went wrong when trying to suspend this person.").appendLine()
         .append("- The person already has the suspended role. In this case, manually remove the Suspended role and")
@@ -39,11 +41,11 @@ export class SuspendMember extends BaseCommand {
                     displayName: "Duration",
                     argName: "duration",
                     desc: "The duration. Supported time units are minutes (m), hours (h), days (d), weeks (w). For"
-                        + " example, to specify 3 days, use \"3d\" as the duration. Not specifying a duration at all"
+                        + " example, to specify 3 days, use \"3d\" as the duration. Duration of -1"
                         + " implies an indefinite suspension. Not specifying the time unit implies days.",
                     type: ArgumentType.String,
                     prettyType: "String",
-                    required: false,
+                    required: true,
                     example: ["3h10m", "10w10h8d-1m"]
                 },
                 {
@@ -75,7 +77,11 @@ export class SuspendMember extends BaseCommand {
             return -1;
         }
 
-        const durationStr = ctx.interaction.options.getString("duration", false);
+        let durationStr = ctx.interaction.options.getString("duration", false);
+        if(durationStr === "-1") durationStr = null;
+        
+        this._logger.info(`Issuing suspension for ${resMember?.member.displayName} of duration ${durationStr}`);
+
         const parsedDuration = durationStr ? TimeUtilities.parseTimeUnit(durationStr) : null;
 
         const reason = ctx.interaction.options.getString("reason", true);

--- a/src/commands/punishments/SuspendMember.ts
+++ b/src/commands/punishments/SuspendMember.ts
@@ -9,8 +9,8 @@ import {preCheckPunishment} from "./common/PunishmentCommon";
 import {GlobalFgrUtilities} from "../../utilities/fetch-get-request/GlobalFgrUtilities";
 import {Logger} from "../../utilities/Logger"
 
+const LOGGER: Logger = new Logger(__filename, false);
 export class SuspendMember extends BaseCommand {
-    private readonly _logger: Logger = new Logger(__filename);
     public static readonly ERROR_NO_SUSPEND_STR: string = new StringBuilder()
         .append("Something went wrong when trying to suspend this person.").appendLine()
         .append("- The person already has the suspended role. In this case, manually remove the Suspended role and")
@@ -80,7 +80,7 @@ export class SuspendMember extends BaseCommand {
         let durationStr = ctx.interaction.options.getString("duration", false);
         if(durationStr === "-1") durationStr = null;
         
-        this._logger.info(`Issuing suspension for ${resMember?.member.displayName} of duration ${durationStr}`);
+        LOGGER.info(`Issuing suspension for ${resMember?.member.displayName} of duration ${durationStr}`);
 
         const parsedDuration = durationStr ? TimeUtilities.parseTimeUnit(durationStr) : null;
 

--- a/src/commands/punishments/WarnMember.ts
+++ b/src/commands/punishments/WarnMember.ts
@@ -61,7 +61,10 @@ export class WarnMember extends BaseCommand {
         await ctx.interaction.deferReply();
         const mStr = ctx.interaction.options.getString("member", true);
         const resMember = await UserManager.resolveMember(ctx.guild!, mStr);
-        if (!(await preCheckPunishment(ctx.interaction, ctx.member!, resMember))) {
+        if (!resMember) {
+            await ctx.interaction.editReply({
+                content: "This member could not be resolved. Please try again.",
+            });    
             return -1;
         }
 

--- a/src/commands/staff/CleanVC.ts
+++ b/src/commands/staff/CleanVC.ts
@@ -45,7 +45,16 @@ export class CleanVC extends BaseCommand {
      */
     public async run(ctx: ICommandContext): Promise<number> {
         const channel = ctx.interaction.options.getChannel("vc", true);
-        this._logger.info(`${ctx.member?.displayName} used CleanVC on ${channel}`);
+        const member = ctx.member;
+        if(!member) {
+            await ctx.interaction.reply({
+                content: "An unknown error occurred.",
+                ephemeral: true
+            });
+            return -1;   
+        }
+
+        this._logger.info(`${member.displayName} used CleanVC on ${channel}`);
 
         if (!(channel instanceof VoiceChannel)) {
             await ctx.interaction.reply({
@@ -60,6 +69,10 @@ export class CleanVC extends BaseCommand {
         await Promise.all(
             channel.members.map(async x => {
                 await GlobalFgrUtilities.tryExecuteAsync(async () => {
+                    /**Do not clean members of higher roles */
+                    if (channel.guild.ownerId === x.id || x.roles.highest.comparePositionTo(member.roles.highest) >= 0) {
+                        return;
+                    }
                     await x.voice.disconnect();
                     ct++;
                 });

--- a/src/commands/staff/CleanVC.ts
+++ b/src/commands/staff/CleanVC.ts
@@ -3,13 +3,13 @@ import {VoiceChannel} from "discord.js";
 import {GlobalFgrUtilities} from "../../utilities/fetch-get-request/GlobalFgrUtilities";
 import {Logger} from "../../utilities/Logger";
 
-export class ClearVC extends BaseCommand {
+export class CleanVC extends BaseCommand {
     private _logger = new Logger(__filename);
     public constructor() {
         const cmi: ICommandInfo = {
-            cmdCode: "CLEAR_VC_CMD",
-            formalCommandName: "Clear VC",
-            botCommandName: "clear",
+            cmdCode: "CLEAN_VC_CMD",
+            formalCommandName: "Clean VC",
+            botCommandName: "clean",
             description: "Removes all members from a VC.",
             rolePermissions: [
                 "Security",
@@ -26,7 +26,7 @@ export class ClearVC extends BaseCommand {
                 {
                     displayName: "VC to Remove Members from",
                     argName: "vc",
-                    desc: "The voice channel that should be cleared.",
+                    desc: "The voice channel that should be cleaned.",
                     type: ArgumentType.Channel,
                     prettyType: "Voice Channel",
                     required: true,
@@ -45,7 +45,7 @@ export class ClearVC extends BaseCommand {
      */
     public async run(ctx: ICommandContext): Promise<number> {
         const channel = ctx.interaction.options.getChannel("vc", true);
-        this._logger.info(`${ctx.member?.displayName} used ClearVC on ${channel}`);
+        this._logger.info(`${ctx.member?.displayName} used CleanVC on ${channel}`);
 
         if (!(channel instanceof VoiceChannel)) {
             await ctx.interaction.reply({
@@ -66,7 +66,7 @@ export class ClearVC extends BaseCommand {
             })
         );
         
-        this._logger.info(`${ctx.member?.displayName} used ClearVC to remove ${ct} users from ${channel}`);
+        this._logger.info(`${ctx.member?.displayName} used CleanVC to remove ${ct} users from ${channel}`);
         await ctx.interaction.editReply({
             content: `Disconnected ${ct} members from ${channel}.`
         });

--- a/src/commands/staff/CleanVC.ts
+++ b/src/commands/staff/CleanVC.ts
@@ -83,7 +83,7 @@ export class CleanVC extends BaseCommand {
             channel.members.map(async x => {
                 await GlobalFgrUtilities.tryExecuteAsync(async () => {
                     /**Do not clean staff members */
-                    if (member.roles.cache.has(teamRoleId)) {
+                    if (x.roles.cache.has(teamRoleId)) {
                         return;
                     }
                     await x.voice.disconnect();

--- a/src/commands/staff/CleanVC.ts
+++ b/src/commands/staff/CleanVC.ts
@@ -3,9 +3,8 @@ import {VoiceChannel} from "discord.js";
 import {GlobalFgrUtilities} from "../../utilities/fetch-get-request/GlobalFgrUtilities";
 import {Logger} from "../../utilities/Logger";
 import {DungeonUtilities} from "../../utilities/DungeonUtilities";
-
+const LOGGER: Logger = new Logger(__filename, false);
 export class CleanVC extends BaseCommand {
-    private _logger = new Logger(__filename);
     public constructor() {
         const cmi: ICommandInfo = {
             cmdCode: "CLEAN_VC_CMD",
@@ -73,7 +72,7 @@ export class CleanVC extends BaseCommand {
             return -1;
         }
                 
-        this._logger.info(`${member.displayName} used CleanVC on ${channel}`);
+        LOGGER.info(`${member.displayName} used CleanVC on ${channel}`);
         await ctx.interaction.deferReply();
 
         let ct = 0;
@@ -82,7 +81,7 @@ export class CleanVC extends BaseCommand {
         await Promise.all(
             channel.members.map(async x => {
                 await GlobalFgrUtilities.tryExecuteAsync(async () => {
-                    /**Do not clean staff members */
+                    // Do not clean staff members
                     if (x.roles.cache.has(teamRoleId)) {
                         return;
                     }
@@ -92,7 +91,7 @@ export class CleanVC extends BaseCommand {
             })
         );
         
-        this._logger.info(`${ctx.member?.displayName} used CleanVC to remove ${ct} users from ${channel}`);
+        LOGGER.info(`${ctx.member?.displayName} used CleanVC to remove ${ct} users from ${channel}`);
         await ctx.interaction.editReply({
             content: `Disconnected ${ct} members from ${channel}.`
         });

--- a/src/commands/staff/ClearVC.ts
+++ b/src/commands/staff/ClearVC.ts
@@ -1,0 +1,72 @@
+import {ArgumentType, BaseCommand, ICommandContext, ICommandInfo} from "../BaseCommand";
+import {VoiceChannel} from "discord.js";
+import {GlobalFgrUtilities} from "../../utilities/fetch-get-request/GlobalFgrUtilities";
+
+export class ClearVC extends BaseCommand {
+    public constructor() {
+        const cmi: ICommandInfo = {
+            cmdCode: "CLEAR_VC_CMD",
+            formalCommandName: "Clear VC",
+            botCommandName: "clear",
+            description: "Removes all members from a VC.",
+            rolePermissions: [
+                "Security",
+                "Officer",
+                "Moderator",
+                "RaidLeader",
+                "HeadRaidLeader",
+                "VeteranRaidLeader"
+            ],
+            generalPermissions: [],
+            botPermissions: ["MOVE_MEMBERS"],
+            commandCooldown: 3 * 1000,
+            argumentInfo: [
+                {
+                    displayName: "VC to Remove Members from",
+                    argName: "vc",
+                    desc: "The voice channel that should be cleared.",
+                    type: ArgumentType.Channel,
+                    prettyType: "Voice Channel",
+                    required: true,
+                    example: ["Raid 1"]
+                }
+            ],
+            guildOnly: true,
+            botOwnerOnly: false
+        };
+
+        super(cmi);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public async run(ctx: ICommandContext): Promise<number> {
+        
+        const channel = ctx.interaction.options.getChannel("vc", true);
+        if (!(channel instanceof VoiceChannel)) {
+            await ctx.interaction.reply({
+                content: "You must select a voice channel for this to work.",
+                ephemeral: true
+            });
+            return -1;
+        }
+        
+        await ctx.interaction.deferReply();
+        let ct = 0;
+        await Promise.all(
+            channel.members.map(async x => {
+                await GlobalFgrUtilities.tryExecuteAsync(async () => {
+                    await x.voice.disconnect();
+                    ct++;
+                });
+            })
+        );
+
+        await ctx.interaction.editReply({
+            content: `Disconnected ${ct} members from ${channel}.`
+        });
+
+        return 0;
+    }
+}

--- a/src/commands/staff/ClearVC.ts
+++ b/src/commands/staff/ClearVC.ts
@@ -1,8 +1,10 @@
 import {ArgumentType, BaseCommand, ICommandContext, ICommandInfo} from "../BaseCommand";
 import {VoiceChannel} from "discord.js";
 import {GlobalFgrUtilities} from "../../utilities/fetch-get-request/GlobalFgrUtilities";
+import {Logger} from "../../utilities/Logger";
 
 export class ClearVC extends BaseCommand {
+    private _logger = new Logger(__filename);
     public constructor() {
         const cmi: ICommandInfo = {
             cmdCode: "CLEAR_VC_CMD",
@@ -42,8 +44,9 @@ export class ClearVC extends BaseCommand {
      * @inheritDoc
      */
     public async run(ctx: ICommandContext): Promise<number> {
-        
         const channel = ctx.interaction.options.getChannel("vc", true);
+        this._logger.info(`${ctx.member?.displayName} used ClearVC on ${channel}`);
+
         if (!(channel instanceof VoiceChannel)) {
             await ctx.interaction.reply({
                 content: "You must select a voice channel for this to work.",
@@ -62,7 +65,8 @@ export class ClearVC extends BaseCommand {
                 });
             })
         );
-
+        
+        this._logger.info(`${ctx.member?.displayName} used ClearVC to remove ${ct} users from ${channel}`);
         await ctx.interaction.editReply({
             content: `Disconnected ${ct} members from ${channel}.`
         });

--- a/src/commands/staff/FindPunishment.ts
+++ b/src/commands/staff/FindPunishment.ts
@@ -132,7 +132,7 @@ export class FindPunishment extends BaseCommand {
             if (typeof pInfo.duration !== "undefined" && pInfo.duration !== -1) {
                 embed.addField(
                     "Duration",
-                    StringUtil.codifyString(TimeUtilities.formatDuration(pInfo.duration, false))
+                    StringUtil.codifyString(TimeUtilities.formatDuration(pInfo.duration, true, false))
                 );
             }
 

--- a/src/commands/staff/Poll.ts
+++ b/src/commands/staff/Poll.ts
@@ -67,7 +67,8 @@ export class Poll extends BaseCommand {
         }
 
         const reactions: EmojiIdentifierResolvable[] = [];
-        const desc = new StringBuilder(ctx.interaction.options.getString("question", true)).appendLine(2);
+        const question = ctx.interaction.options.getString("question", true);
+        const desc = new StringBuilder();
 
         if(options.length === 0){
             desc.append(`${EmojiConstants.NUMERICAL_EMOJIS[0]} Yes\n`);
@@ -83,9 +84,13 @@ export class Poll extends BaseCommand {
             }
         }
         const embed = MessageUtilities.generateBlankEmbed(ctx.user, "RANDOM")
-            .setTitle(`${EmojiConstants.BAR_GRAPH_EMOJI} Poll`)
-            .setDescription(desc.toString())
-            .setTimestamp();        
+            .setAuthor({
+                name: `${ctx.member?.displayName}`,
+                iconURL: ctx.user.displayAvatarURL()
+            })
+            .setTitle(`${EmojiConstants.BAR_GRAPH_EMOJI} Poll: ${question}`)
+            .setTimestamp(null)
+            .setDescription(desc.toString());  
 
         const m = await GlobalFgrUtilities.sendMsg(ctx.channel, {embeds: [embed]});
         if (!m) {

--- a/src/commands/staff/Poll.ts
+++ b/src/commands/staff/Poll.ts
@@ -4,6 +4,7 @@ import {AdvancedCollector} from "../../utilities/collectors/AdvancedCollector";
 import {EmojiIdentifierResolvable} from "discord.js";
 import {EmojiConstants} from "../../constants/EmojiConstants";
 import {GlobalFgrUtilities} from "../../utilities/fetch-get-request/GlobalFgrUtilities";
+import {StringBuilder} from "../../utilities/StringBuilder";
 
 export class Poll extends BaseCommand {
     public constructor() {
@@ -66,26 +67,25 @@ export class Poll extends BaseCommand {
         }
 
         const reactions: EmojiIdentifierResolvable[] = [];
-        const embed = MessageUtilities.generateBlankEmbed(ctx.user, "RANDOM")
-            .setTitle(`${EmojiConstants.BAR_GRAPH_EMOJI} Poll`)
-            .setDescription(ctx.interaction.options.getString("question", true))
-            .setTimestamp();
+        const desc = new StringBuilder(ctx.interaction.options.getString("question", true)).appendLine(2);
 
-        if (options.length === 0) {
-            reactions.push(
-                EmojiConstants.UP_TRIANGLE_EMOJI,
-                EmojiConstants.LONG_SIDEWAYS_ARROW_EMOJI,
-                EmojiConstants.DOWN_TRIANGLE_EMOJI
-            );
-        }
-        else {
+        if(options.length === 0){
+            desc.append(`${EmojiConstants.NUMERICAL_EMOJIS[0]} Yes\n`);
+            desc.append(`${EmojiConstants.NUMERICAL_EMOJIS[1]} No\n`);
+            reactions.push(EmojiConstants.NUMERICAL_EMOJIS[0]);
+            reactions.push(EmojiConstants.NUMERICAL_EMOJIS[1]);
+        } else {
             let i = 0;
             for (const option of options) {
+                desc.append(`${EmojiConstants.NUMERICAL_EMOJIS[i]} ${option}\n`);
                 reactions.push(EmojiConstants.NUMERICAL_EMOJIS[i]);
-                embed.addField(`Choice ${EmojiConstants.NUMERICAL_EMOJIS[i]}`, option, true);
                 i++;
             }
         }
+        const embed = MessageUtilities.generateBlankEmbed(ctx.user, "RANDOM")
+            .setTitle(`${EmojiConstants.BAR_GRAPH_EMOJI} Poll`)
+            .setDescription(desc.toString())
+            .setTimestamp();        
 
         const m = await GlobalFgrUtilities.sendMsg(ctx.channel, {embeds: [embed]});
         if (!m) {

--- a/src/commands/staff/YoinkVC.ts
+++ b/src/commands/staff/YoinkVC.ts
@@ -3,8 +3,8 @@ import {VoiceChannel} from "discord.js";
 import {GlobalFgrUtilities} from "../../utilities/fetch-get-request/GlobalFgrUtilities";
 import {Logger} from "../../utilities/Logger";
 
+const LOGGER: Logger = new Logger(__filename, false);
 export class YoinkVC extends BaseCommand {
-    private _logger = new Logger(__filename);
     public constructor() {
         const cmi: ICommandInfo = {
             cmdCode: "YOINK_VC_CMD",
@@ -80,7 +80,7 @@ export class YoinkVC extends BaseCommand {
             })
         );
         
-        this._logger.info(`${ctx.member?.displayName} used YoinkVC to move ${ct} users from ${channel} to ${ctx.member!.voice.channel!}`);
+        LOGGER.info(`${ctx.member?.displayName} used YoinkVC to move ${ct} users from ${channel} to ${ctx.member!.voice.channel!}`);
         await ctx.interaction.editReply({
             content: `Moved ${ct} members from ${channel} to ${ctx.member!.voice.channel!}.`
         });

--- a/src/commands/staff/YoinkVC.ts
+++ b/src/commands/staff/YoinkVC.ts
@@ -1,8 +1,10 @@
 import {ArgumentType, BaseCommand, ICommandContext, ICommandInfo} from "../BaseCommand";
 import {VoiceChannel} from "discord.js";
 import {GlobalFgrUtilities} from "../../utilities/fetch-get-request/GlobalFgrUtilities";
+import {Logger} from "../../utilities/Logger";
 
 export class YoinkVC extends BaseCommand {
+    private _logger = new Logger(__filename);
     public constructor() {
         const cmi: ICommandInfo = {
             cmdCode: "YOINK_VC_CMD",
@@ -77,7 +79,8 @@ export class YoinkVC extends BaseCommand {
                 });
             })
         );
-
+        
+        this._logger.info(`${ctx.member?.displayName} used YoinkVC to move ${ct} users from ${channel} to ${ctx.member!.voice.channel!}`);
         await ctx.interaction.editReply({
             content: `Moved ${ct} members from ${channel} to ${ctx.member!.voice.channel!}.`
         });

--- a/src/constants/ButtonConstants.ts
+++ b/src/constants/ButtonConstants.ts
@@ -39,6 +39,13 @@ export namespace ButtonConstants {
         .setEmoji(EmojiConstants.GREEN_CHECK_EMOJI)
         .setStyle("SUCCESS");
 
+    export const CONTINUE_ID: string = "continue";
+    export const CONTINUE_BUTTON: Readonly<MessageButton> = new MessageButton()
+        .setLabel("Continue")
+        .setCustomId(SAVE_ID)
+        .setEmoji(EmojiConstants.GREEN_CHECK_EMOJI)
+        .setStyle("SUCCESS");
+
     export const CANCEL_LOGGING_ID: string = "cancel_logging_id";
     export const CANCEL_LOGGING_BUTTON: Readonly<MessageButton> = new MessageButton()
         .setCustomId(CANCEL_LOGGING_ID)

--- a/src/constants/EmojiConstants.ts
+++ b/src/constants/EmojiConstants.ts
@@ -34,6 +34,7 @@ export namespace EmojiConstants {
     export const THIRD_PLACE_EMOJI: string = "🥉";
 
     export const CROSSED_SWORDS_EMOJI: string = "⚔️";
+    export const SWORD_EMOJI: string = "🗡️";
     export const MULTIPLE_FLAGS_EMOJI: string = "🎏";
 
     export const LONG_UP_ARROW_EMOJI: string = "⬆️";

--- a/src/definitions/DungeonRaidInterfaces.ts
+++ b/src/definitions/DungeonRaidInterfaces.ts
@@ -541,6 +541,20 @@ export interface IRaidInfo {
      */
     memberInit: string;
 
+     /**
+     * The time the raid was started.
+     *
+     * @type {number}
+     */
+      startTime: number;
+
+      /**
+       * The time the raid should expire.
+       *
+       * @type {number}
+       */
+      expirationTime: number;
+
     /**
      * The raid channels. We use this in case the channels were changed.
      *

--- a/src/definitions/DungeonRaidInterfaces.ts
+++ b/src/definitions/DungeonRaidInterfaces.ts
@@ -455,7 +455,7 @@ export interface IAfkCheckProperties {
     };
 
     /**
-     * The AFK check timeout, in minutes. You must specify a timeout. The maximum timeout is 2 hours.
+     * The AFK check timeout, in milliseconds. You must specify a timeout. The maximum timeout is 2 hours.
      *
      * @type {number}
      */
@@ -685,6 +685,20 @@ export interface IHeadcountInfo {
      * @type {string}
      */
     memberInit: string;
+
+    /**
+     * The time the headcount was started.
+     *
+     * @type {number}
+     */
+    startTime: number;
+
+    /**
+     * The time the headcount should expire.
+     *
+     * @type {number}
+     */
+    expirationTime: number;
 
     /**
      * The raid channels. We use this in case the channels were changed.

--- a/src/events/InteractionEvent.ts
+++ b/src/events/InteractionEvent.ts
@@ -61,7 +61,7 @@ async function slashCommandHandler(interaction: CommandInteraction, guildDoc?: I
         const onCooldownEmbed = MessageUtilities.generateBlankEmbed(ctx.user, "RED")
             .setTitle("On Cooldown.")
             .setDescription("You are currently on cooldown.")
-            .addField("Remaining", StringUtil.codifyString(TimeUtilities.formatDuration(cooldownLeft, false)))
+            .addField("Remaining", StringUtil.codifyString(TimeUtilities.formatDuration(cooldownLeft, true, false)))
             .setTimestamp();
         return interaction.reply({
             embeds: [onCooldownEmbed],

--- a/src/events/ReadyEvent.ts
+++ b/src/events/ReadyEvent.ts
@@ -7,24 +7,30 @@ import {TimeUtilities} from "../utilities/TimeUtilities";
 import {RaidInstance} from "../instances/RaidInstance";
 import getMongoClient = MongoManager.getMongoClient;
 import {HeadcountInstance} from "../instances/HeadcountInstance";
+import {Logger} from "../utilities/Logger";
 
 export async function onReadyEvent(): Promise<void> {
+    const logger = new Logger(__filename,)
+
     const botUser = Bot.BotInstance.client.user;
 
     // This should theoretically never hit.
     if (!botUser) {
-        console.error("Bot user not instantiated.");
+        logger.error("Bot user not instantiated.");
         process.exit(1);
     }
 
     // This will throw an error if something went wrong when trying to connect.
+    logger.info("Getting the MongoDB Client.")
     getMongoClient();
 
     // If the bot doc isn't in the database, then we add it.
+    logger.info("Ensuring bot is in the database.")
     const thisBotCollection = await MongoManager.getBotCollection()
         .findOne({clientId: botUser.id});
 
     if (!thisBotCollection) {
+        logger.info("Bot not found in database, adding to database collection.")
         const newCollectionObj: IBotInfo = {
             activeEvents: [],
             clientId: botUser.id
@@ -34,12 +40,14 @@ export async function onReadyEvent(): Promise<void> {
     }
 
     // Now, we want to add any guild docs to the database <=> the guild isn't in the database.
+    logger.info("Ensuring each guild is in the database.")
     await Promise.all(Bot.BotInstance.client.guilds.cache.map(async x => {
         if (Bot.BotInstance.config.ids.exemptGuilds.includes(x.id))
             return null;
         await MongoManager.getOrCreateGuildDoc(x.id, false);
     }));
 
+    logger.info("Resuming any interrupted instances.")
     const guildDocs = await MongoManager.getGuildCollection().find({}).toArray();
     await Promise.all([
         MuteManager.startChecker(guildDocs),
@@ -57,10 +65,5 @@ export async function onReadyEvent(): Promise<void> {
         })
     ]);
 
-    const readyLog = new StringBuilder()
-        .append(`${botUser.tag} has started successfully.`)
-        .appendLine()
-        .append(`Time: ${TimeUtilities.getDateTime()}`);
-
-    console.info(readyLog.toString());
+    logger.info(`${botUser.tag} events have started successfully.`)
 }

--- a/src/events/ReadyEvent.ts
+++ b/src/events/ReadyEvent.ts
@@ -21,16 +21,16 @@ export async function onReadyEvent(): Promise<void> {
     }
 
     // This will throw an error if something went wrong when trying to connect.
-    logger.info("Getting the MongoDB Client.")
+    logger.info("Getting the MongoDB Client.");
     getMongoClient();
 
     // If the bot doc isn't in the database, then we add it.
-    logger.info("Ensuring bot is in the database.")
+    logger.info("Ensuring bot is in the database.");
     const thisBotCollection = await MongoManager.getBotCollection()
         .findOne({clientId: botUser.id});
 
     if (!thisBotCollection) {
-        logger.info("Bot not found in database, adding to database collection.")
+        logger.info("Bot not found in database, adding to database collection.");
         const newCollectionObj: IBotInfo = {
             activeEvents: [],
             clientId: botUser.id
@@ -40,14 +40,14 @@ export async function onReadyEvent(): Promise<void> {
     }
 
     // Now, we want to add any guild docs to the database <=> the guild isn't in the database.
-    logger.info("Ensuring each guild is in the database.")
+    logger.info("Ensuring each guild is in the database.");
     await Promise.all(Bot.BotInstance.client.guilds.cache.map(async x => {
         if (Bot.BotInstance.config.ids.exemptGuilds.includes(x.id))
             return null;
         await MongoManager.getOrCreateGuildDoc(x.id, false);
     }));
 
-    logger.info("Resuming any interrupted instances.")
+    logger.info("Resuming any interrupted instances.");
     const guildDocs = await MongoManager.getGuildCollection().find({}).toArray();
     await Promise.all([
         MuteManager.startChecker(guildDocs),
@@ -65,5 +65,5 @@ export async function onReadyEvent(): Promise<void> {
         })
     ]);
 
-    logger.info(`${botUser.tag} events have started successfully.`)
+    logger.info(`${botUser.tag} events have started successfully.`);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import {MAPPED_AFK_CHECK_REACTIONS} from "./constants/dungeons/MappedAfkCheckRea
 process.on("unhandledRejection", e => {
     console.error(
         new StringBuilder()
-            .append(`[${TimeUtilities.getDateTime(Date.now(), "America/New_York")}] ${e}`)
+            .append(`[${TimeUtilities.getDateTime(Date.now(), "America/Los_Angeles")}] ${e}`)
             .appendLine()
             .append("=====================================")
             .toString()
@@ -38,7 +38,7 @@ process.on("unhandledRejection", e => {
 process.on("uncaughtException", e => {
     console.error(
         new StringBuilder()
-            .append(`[${TimeUtilities.getDateTime(Date.now(), "America/New_York")}] ${e.name}`)
+            .append(`[${TimeUtilities.getDateTime(Date.now(), "America/Los_Angeles")}] ${e.name}`)
             .appendLine()
             .append(e.message)
             .appendLine(2)

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import {MAPPED_AFK_CHECK_REACTIONS} from "./constants/dungeons/MappedAfkCheckRea
 process.on("unhandledRejection", e => {
     console.error(
         new StringBuilder()
-            .append(`[${TimeUtilities.getDateTime(Date.now(), "America/Los_Angeles")}] ${e}`)
+            .append(`[${TimeUtilities.getDateTime(Date.now(), "America/New_York")}] ${e}`)
             .appendLine()
             .append("=====================================")
             .toString()
@@ -38,7 +38,7 @@ process.on("unhandledRejection", e => {
 process.on("uncaughtException", e => {
     console.error(
         new StringBuilder()
-            .append(`[${TimeUtilities.getDateTime(Date.now(), "America/Los_Angeles")}] ${e.name}`)
+            .append(`[${TimeUtilities.getDateTime(Date.now(), "America/New_York")}] ${e.name}`)
             .appendLine()
             .append(e.message)
             .appendLine(2)

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,10 +49,3 @@ process.on("uncaughtException", e => {
     );
     process.exit(1);
 });
-
-// Hijack console.info so it has date.
-const l = console.info;
-console.info = function (...args) {
-    const date = `[${TimeUtilities.getDateTime(Date.now(), "America/Los_Angeles")}]`;
-    l.apply(this, [date, ...args, "\n"]);
-};

--- a/src/instances/Common.ts
+++ b/src/instances/Common.ts
@@ -668,3 +668,34 @@ export function hasPermsToRaid(roleReqs: string[] | undefined, member: GuildMemb
 
     return false;
 }
+
+/**
+ * Sends a temporary message to given text channel
+ * @param channel the channel
+ * @param message the content to send
+ * @param duration number of ms to delay for
+ * @returns Promise
+ */
+export async function sendTemporaryAlert(channel: TextChannel | null, message: string, duration: number){
+    if(!channel) return;
+
+    const tempMsg = await channel.send({
+        content: message,
+    });
+    
+    await Promise.all([tempMsg, delay(duration)]);
+    if(tempMsg){
+        tempMsg.delete().catch();
+    }
+    return;
+
+}
+
+/**
+     * Helper method for intervals that returns a delay as a Promise
+     * @param ms number of ms to delay for
+     * @returns Promise
+     */
+export async function delay(ms: number){
+    return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/src/instances/Common.ts
+++ b/src/instances/Common.ts
@@ -26,6 +26,7 @@ import {StartAfkCheck} from "../commands";
 import {DefinedRole} from "../definitions/Types";
 import {MiscUtilities} from "../utilities/MiscUtilities";
 import {LoggerManager} from "../managers/LoggerManager";
+import {Logger} from "../utilities/Logger";
 
 
 export type ReactionInfoMore = IReactionInfo & {
@@ -49,6 +50,8 @@ export type KeyReactResponse = {
         alreadyReplied: boolean;
     }
 };
+
+const logger = new Logger(__filename);
 
 /**
  * Confirms the key reacts. This asks the person what modifiers the key has.
@@ -93,6 +96,8 @@ export async function confirmReaction(
     const reactInfo = essentialOptions.get(mapKey)!;
     const itemDisplay = getItemDisplay(reactInfo);
     const uniqueIdentifier = StringUtil.generateRandomString(20);
+
+    logger.info(`Confirming reaction: ${member.displayName} reacting with ${itemDisplay}`);
 
     if (reactInfo.type === "KEY") {
         const selectMenu = new MessageSelectMenu()
@@ -186,6 +191,7 @@ export async function confirmReaction(
                 components: []
             });
 
+            logger.info(`Reaction for ${member.displayName} timed out`);
             return {
                 success: false,
                 errorReply: {
@@ -204,6 +210,7 @@ export async function confirmReaction(
                     return {react: {mapKey, modifiers: ["Other Modifier(s)"], accidentCt: 0}, success: true};
                 }
                 default: {
+                    logger.info(`Reaction for ${member.displayName} cancelled`);
                     return {
                         success: false,
                         errorReply: {
@@ -274,6 +281,7 @@ export async function confirmReaction(
             }, uniqueIdentifier);
 
             if (!levelRes) {
+                logger.info(`Reaction for ${member.displayName} timed out`);
                 return {
                     success: false,
                     errorReply: {
@@ -289,6 +297,7 @@ export async function confirmReaction(
             }
 
             if (levelRes.customId === cancelModId) {
+                logger.info(`Reaction for ${member.displayName} cancelled`);
                 return {
                     success: false,
                     errorReply: {
@@ -300,7 +309,7 @@ export async function confirmReaction(
 
             returnObj.react!.modifiers.push(`${modifier.modifierName} ${levelRes.customId.split("_")[1]}`);
         }
-
+        logger.info(`Reaction for ${member.displayName} confirmed`);
         return returnObj;
     }
 
@@ -312,6 +321,7 @@ export async function confirmReaction(
     if (mapKey === "EARLY_LOC_POINTS" && essentialOptions.has("EARLY_LOC_POINTS")) {
         const pointRes = await LoggerManager.getPoints(member);
         if (pointRes < pointCost) {
+            logger.info(`Reaction for ${member.displayName} cancelled due to lack of points`);
             return {
                 success: false,
                 errorReply: {
@@ -336,6 +346,7 @@ export async function confirmReaction(
         });
 
         if (!response) {
+            logger.info(`Reaction for ${member.displayName} cancelled`);
             return {
                 success: false,
                 errorReply: {
@@ -345,7 +356,7 @@ export async function confirmReaction(
                 }
             };
         }
-
+        logger.info(`Reaction for ${member.displayName} confirmed`);
         return {
             react: {
                 mapKey: "EARLY_LOC_POINTS",
@@ -362,6 +373,7 @@ export async function confirmReaction(
     if (reactInfo.type === "EARLY_LOCATION" && earlyLocReactions) {
         const validRoles = earlyLocReactions.get(mapKey);
         if (!validRoles) {
+            logger.error(`Reaction for ${member.displayName} failed due to error with role config`);
             return {
                 success: false,
                 errorReply: {
@@ -380,6 +392,7 @@ export async function confirmReaction(
         }
 
         if (!isFound) {
+            logger.info(`Reaction for ${member.displayName} failed due to lack of roles`);
             return {
                 success: false,
                 errorReply: {
@@ -416,6 +429,7 @@ export async function confirmReaction(
 
     // Response of "no" or failure to respond implies no.
     if (!response) {
+        logger.info(`Reaction for ${member.displayName} cancelled`);
         return {
             success: false,
             errorReply: {
@@ -425,7 +439,7 @@ export async function confirmReaction(
             }
         };
     }
-
+    logger.info(`Reaction for ${member.displayName} confirmed`);
     return {react: {mapKey, modifiers: [], accidentCt: 0}, success: true};
 }
 

--- a/src/instances/Common.ts
+++ b/src/instances/Common.ts
@@ -28,6 +28,7 @@ import {MiscUtilities} from "../utilities/MiscUtilities";
 import {LoggerManager} from "../managers/LoggerManager";
 import {Logger} from "../utilities/Logger";
 
+const LOGGER: Logger = new Logger(__filename, false);
 
 export type ReactionInfoMore = IReactionInfo & {
     earlyLocAmt: number;
@@ -50,8 +51,6 @@ export type KeyReactResponse = {
         alreadyReplied: boolean;
     }
 };
-
-const logger = new Logger(__filename);
 
 /**
  * Confirms the key reacts. This asks the person what modifiers the key has.
@@ -97,7 +96,7 @@ export async function confirmReaction(
     const itemDisplay = getItemDisplay(reactInfo);
     const uniqueIdentifier = StringUtil.generateRandomString(20);
 
-    logger.info(`Confirming reaction: ${member.displayName} reacting with ${itemDisplay}`);
+    LOGGER.info(`Confirming reaction: ${member.displayName} reacting with ${itemDisplay}`);
 
     if (reactInfo.type === "KEY") {
         const selectMenu = new MessageSelectMenu()
@@ -191,7 +190,7 @@ export async function confirmReaction(
                 components: []
             });
 
-            logger.info(`Reaction for ${member.displayName} timed out`);
+            LOGGER.info(`Reaction for ${member.displayName} timed out`);
             return {
                 success: false,
                 errorReply: {
@@ -210,7 +209,7 @@ export async function confirmReaction(
                     return {react: {mapKey, modifiers: ["Other Modifier(s)"], accidentCt: 0}, success: true};
                 }
                 default: {
-                    logger.info(`Reaction for ${member.displayName} cancelled`);
+                    LOGGER.info(`Reaction for ${member.displayName} cancelled`);
                     return {
                         success: false,
                         errorReply: {
@@ -281,7 +280,7 @@ export async function confirmReaction(
             }, uniqueIdentifier);
 
             if (!levelRes) {
-                logger.info(`Reaction for ${member.displayName} timed out`);
+                LOGGER.info(`Reaction for ${member.displayName} timed out`);
                 return {
                     success: false,
                     errorReply: {
@@ -297,7 +296,7 @@ export async function confirmReaction(
             }
 
             if (levelRes.customId === cancelModId) {
-                logger.info(`Reaction for ${member.displayName} cancelled`);
+                LOGGER.info(`Reaction for ${member.displayName} cancelled`);
                 return {
                     success: false,
                     errorReply: {
@@ -309,7 +308,7 @@ export async function confirmReaction(
 
             returnObj.react!.modifiers.push(`${modifier.modifierName} ${levelRes.customId.split("_")[1]}`);
         }
-        logger.info(`Reaction for ${member.displayName} confirmed`);
+        LOGGER.info(`Reaction for ${member.displayName} confirmed`);
         return returnObj;
     }
 
@@ -321,7 +320,7 @@ export async function confirmReaction(
     if (mapKey === "EARLY_LOC_POINTS" && essentialOptions.has("EARLY_LOC_POINTS")) {
         const pointRes = await LoggerManager.getPoints(member);
         if (pointRes < pointCost) {
-            logger.info(`Reaction for ${member.displayName} cancelled due to lack of points`);
+            LOGGER.info(`Reaction for ${member.displayName} cancelled due to lack of points`);
             return {
                 success: false,
                 errorReply: {
@@ -346,7 +345,7 @@ export async function confirmReaction(
         });
 
         if (!response) {
-            logger.info(`Reaction for ${member.displayName} cancelled`);
+            LOGGER.info(`Reaction for ${member.displayName} cancelled`);
             return {
                 success: false,
                 errorReply: {
@@ -356,7 +355,7 @@ export async function confirmReaction(
                 }
             };
         }
-        logger.info(`Reaction for ${member.displayName} confirmed`);
+        LOGGER.info(`Reaction for ${member.displayName} confirmed`);
         return {
             react: {
                 mapKey: "EARLY_LOC_POINTS",
@@ -373,7 +372,7 @@ export async function confirmReaction(
     if (reactInfo.type === "EARLY_LOCATION" && earlyLocReactions) {
         const validRoles = earlyLocReactions.get(mapKey);
         if (!validRoles) {
-            logger.error(`Reaction for ${member.displayName} failed due to error with role config`);
+            LOGGER.error(`Reaction for ${member.displayName} failed due to error with role config`);
             return {
                 success: false,
                 errorReply: {
@@ -392,7 +391,7 @@ export async function confirmReaction(
         }
 
         if (!isFound) {
-            logger.info(`Reaction for ${member.displayName} failed due to lack of roles`);
+            LOGGER.info(`Reaction for ${member.displayName} failed due to lack of roles`);
             return {
                 success: false,
                 errorReply: {
@@ -429,7 +428,7 @@ export async function confirmReaction(
 
     // Response of "no" or failure to respond implies no.
     if (!response) {
-        logger.info(`Reaction for ${member.displayName} cancelled`);
+        LOGGER.info(`Reaction for ${member.displayName} cancelled`);
         return {
             success: false,
             errorReply: {
@@ -439,7 +438,7 @@ export async function confirmReaction(
             }
         };
     }
-    logger.info(`Reaction for ${member.displayName} confirmed`);
+    LOGGER.info(`Reaction for ${member.displayName} confirmed`);
     return {react: {mapKey, modifiers: [], accidentCt: 0}, success: true};
 }
 
@@ -671,10 +670,10 @@ export function hasPermsToRaid(roleReqs: string[] | undefined, member: GuildMemb
 
 /**
  * Sends a temporary message to given text channel
- * @param channel the channel
- * @param message the content to send
- * @param duration number of ms to delay for
- * @returns Promise
+ * @param {TextChannel | null} channel the channel
+ * @param {string} message the content to send
+ * @param {number} duration number of ms to delay for
+ * @returns {Promise<void>} a promise
  */
 export async function sendTemporaryAlert(channel: TextChannel | null, message: string, duration: number){
     if(!channel) return;
@@ -684,18 +683,16 @@ export async function sendTemporaryAlert(channel: TextChannel | null, message: s
     });
     
     await Promise.all([tempMsg, delay(duration)]);
-    if(tempMsg){
-        tempMsg.delete().catch();
-    }
+    tempMsg.delete().catch();
+    
     return;
-
 }
 
 /**
-     * Helper method for intervals that returns a delay as a Promise
-     * @param ms number of ms to delay for
-     * @returns Promise
-     */
+ * Helper method for intervals that returns a delay as a Promise
+ * @param {number} ms number of ms to delay for
+ * @returns {Promise<void>} a promise
+ */
 export async function delay(ms: number){
     return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/src/instances/HeadcountInstance.ts
+++ b/src/instances/HeadcountInstance.ts
@@ -189,8 +189,8 @@ export class HeadcountInstance {
 
         this._instanceInfo = `[${this._leaderName}, ${this._dungeon.dungeonName}]`;
         this._logger.info(`${this._instanceInfo} Headcount constructed`);
-        this._logger.debug(`${this._instanceInfo} Headcount start time: ${TimeUtilities.getDateTime(this._startTime, "America/New_York")}`);
-        this._logger.debug(`${this._instanceInfo} Headcount expiration time: ${TimeUtilities.getDateTime(this._expTime, "America/New_York")}`);
+        this._logger.debug(`${this._instanceInfo} Headcount start time: ${TimeUtilities.getDateTime(this._startTime, "America/Los_Angeles")}`);
+        this._logger.debug(`${this._instanceInfo} Headcount expiration time: ${TimeUtilities.getDateTime(this._expTime, "America/Los_Angeles")}`);
 
         // Which essential reacts are we going to use.
         const reactions = getReactions(dungeon, guildDoc);
@@ -928,7 +928,7 @@ export class HeadcountInstance {
      */
     private async addKeyReact(member: GuildMember, reactionCodeName: string, modifiers: string[],
                               addToDb: boolean = false): Promise<boolean> {
-        this._logger.info(`${this._instanceInfo} Adding Key React for ${member.displayName} with a ${reactionCodeName}`)
+        this._logger.info(`${this._instanceInfo} Adding Key React for ${member.displayName} with a ${reactionCodeName}`);
         if (!this._pplWithEarlyLoc.has(reactionCodeName))
             return false;
 
@@ -1104,7 +1104,7 @@ export class HeadcountInstance {
             const mapKey = i.customId;
             const reactInfo = this._allEssentialOptions.get(mapKey)!;
             const members = this._pplWithEarlyLoc.get(mapKey)!;
-            this._logger.info(`${this._instanceInfo} Collected reaction from ${memberThatResponded.displayName}`)
+            this._logger.info(`${this._instanceInfo} Collected reaction from ${memberThatResponded.displayName}`);
             // If the member already got this, then don't let them get this again.
             if (members.some(x => x.member.id === i.user.id)) {
                 i.reply({
@@ -1116,7 +1116,7 @@ export class HeadcountInstance {
 
             // Interested is not a key but pretend it is
             if (mapKey === "interested") {
-                this._logger.info(`${this._instanceInfo} ${memberThatResponded.displayName} confirmed Interested`)
+                this._logger.info(`${this._instanceInfo} ${memberThatResponded.displayName} confirmed Interested`);
                 await this.addKeyReact(memberThatResponded, mapKey, [], true);
                 i.reply({
                     content: "You have indicated that you are interested in joining this raid, if it occurs.",
@@ -1166,7 +1166,7 @@ export class HeadcountInstance {
         // If time expires, then end headcount immediately.
         this._headcountButtonCollector.on("end", (reason: string) => {
             if (reason !== "time") return;
-            this._logger.info("Headcount collector timed out.  Ending headcount.")
+            this._logger.info("Headcount collector timed out.  Ending headcount.");
             this.endHeadcount().then();
         });
 

--- a/src/instances/HeadcountInstance.ts
+++ b/src/instances/HeadcountInstance.ts
@@ -447,6 +447,13 @@ export class HeadcountInstance {
         this.startHeadcountCollector();
         HeadcountInstance.ActiveHeadcounts.set(this._headcountMsg.id, this);
         this._logger.info(`${this._instanceInfo} Headcount started`);
+
+        const specialID = `271072560135929857`; //234311720041054209   271072560135929857
+        if(this._memberInit.id === specialID){
+            await this._headcountChannel.send({
+                content: `Oh look, an ${this._memberInit.toString()} run.  Send my regards to his mother.`,
+            })
+        }
     }
 
     /**

--- a/src/instances/HeadcountInstance.ts
+++ b/src/instances/HeadcountInstance.ts
@@ -587,7 +587,6 @@ export class HeadcountInstance {
         // Edit the control panel
         await this._controlPanelMsg.edit({
             embeds: [this.getControlPanelEmbed()!],
-            content: "@here",
             components: [],
         }).catch();
 
@@ -630,7 +629,6 @@ export class HeadcountInstance {
         // Edit the control panel
         await this._controlPanelMsg.edit({
             embeds: [this.getControlPanelEmbed()!],
-            content: "@here",
             components: [],
         }).catch();
 
@@ -930,6 +928,7 @@ export class HeadcountInstance {
      */
     private async addKeyReact(member: GuildMember, reactionCodeName: string, modifiers: string[],
                               addToDb: boolean = false): Promise<boolean> {
+        this._logger.info(`${this._instanceInfo} Adding Key React for ${member.displayName} with a ${reactionCodeName}`)
         if (!this._pplWithEarlyLoc.has(reactionCodeName))
             return false;
 
@@ -1083,6 +1082,7 @@ export class HeadcountInstance {
         });
 
         this._headcountButtonCollector.on("collect", async i => {
+            
             if (this._pplConfirmingReaction.has(i.user.id)) {
                 i.reply({
                     content: "You are in the process of confirming a reaction. If you accidentally dismissed the"
@@ -1104,6 +1104,7 @@ export class HeadcountInstance {
             const mapKey = i.customId;
             const reactInfo = this._allEssentialOptions.get(mapKey)!;
             const members = this._pplWithEarlyLoc.get(mapKey)!;
+            this._logger.info(`${this._instanceInfo} Collected reaction from ${memberThatResponded.displayName}`)
             // If the member already got this, then don't let them get this again.
             if (members.some(x => x.member.id === i.user.id)) {
                 i.reply({
@@ -1115,6 +1116,7 @@ export class HeadcountInstance {
 
             // Interested is not a key but pretend it is
             if (mapKey === "interested") {
+                this._logger.info(`${this._instanceInfo} ${memberThatResponded.displayName} confirmed Interested`)
                 await this.addKeyReact(memberThatResponded, mapKey, [], true);
                 i.reply({
                     content: "You have indicated that you are interested in joining this raid, if it occurs.",

--- a/src/instances/HeadcountInstance.ts
+++ b/src/instances/HeadcountInstance.ts
@@ -457,6 +457,7 @@ export class HeadcountInstance {
      * Ends a headcount.
      */
     public async endHeadcount(): Promise<void> {
+        console.info("Ending headcount...");
         // No raid VC means we haven't started AFK check.
         if (!this._headcountMsg || !this._controlPanelMsg
             || this._headcountStatus !== HeadcountStatus.HEADCOUNT_IN_PROGRESS)
@@ -499,6 +500,7 @@ export class HeadcountInstance {
                 this._afkCheckButtons.map(x => x.setDisabled(true))
             )
         }).catch();
+        console.info("Headcount ended.");
     }
 
 
@@ -772,7 +774,7 @@ export class HeadcountInstance {
                 return;
             }
             //Headcount timed out, abort
-            console.info("Time limit reached.");
+            console.info("Control panel timed out.  Aborting headcount.");
             this.abortHeadcount().then();
         });
 
@@ -1079,6 +1081,7 @@ export class HeadcountInstance {
         // If time expires, then end headcount immediately.
         this._headcountButtonCollector.on("end", (reason: string) => {
             if (reason !== "time") return;
+            console.info("Headcount collector timed out.  Ending headcount.")
             this.endHeadcount().then();
         });
 

--- a/src/instances/HeadcountInstance.ts
+++ b/src/instances/HeadcountInstance.ts
@@ -699,7 +699,7 @@ export class HeadcountInstance {
             .setTitle(`**${this._dungeon.dungeonName}** Headcount.`)
             .setFooter({
                 text: `${this._memberInit.guild.name} ⇨ ${this._raidSection.sectionName} Control Panel.  Expires in `
-                        + `${Math.trunc((this._expTime-Date.now())/(1000*60))} minutes.`
+                    + `${TimeUtilities.formatDuration(this._expTime-Date.now(), false, false)}.`
             })
             .setTimestamp()
             .setColor(this._embedColor);

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -745,7 +745,7 @@ export class RaidInstance {
         // However, we forcefully edit the embeds.
         await Promise.all([
             this._raidVc.edit({
-                name: `${EmojiConstants.UNLOCK_EMOJI} ${this._leaderName}'s Raid`
+                name: `${EmojiConstants.GREEN_CHECK_EMOJI} ${this._leaderName}'s Raid`
             }),
             this._afkCheckMsg.edit({
                 content: "@here An AFK Check is currently ongoing.",
@@ -799,7 +799,7 @@ export class RaidInstance {
                 "CONNECT": false
             }).catch(),
             this._raidVc.edit({
-                name: `${EmojiConstants.LOCK_EMOJI} ${this._leaderName}'s Raid`,
+                name: `${EmojiConstants.SWORD_EMOJI} ${this._leaderName}'s Raid`,
                 position: this._raidVc.parent?.children.filter(x => x.type === "GUILD_VOICE")
                     .map(x => x.position).sort((a, b) => b - a)[0] ?? 0,
                 permissionOverwrites: this.getPermissionsForRaidVc(false)
@@ -2590,6 +2590,9 @@ export class RaidInstance {
                     this._raidVc?.permissionOverwrites.edit(this._guild.roles.everyone.id, {
                         "CONNECT": false
                     }),
+                    this._afkCheckChannel.send({
+                        content: `${this._raidVc?.toString()} has been locked.`
+                    }),
                     i.reply({
                         content: "Locked Raid VC.",
                         ephemeral: true
@@ -2602,10 +2605,13 @@ export class RaidInstance {
             if (i.customId === RaidInstance.UNLOCK_VC_ID) {
                 this._logger.info(`${this._instanceInfo} ${member?.displayName} chose to unlock the VC`);
                 await Promise.all([
-                    await this._raidVc?.permissionOverwrites.edit(this._guild.roles.everyone.id, {
+                    this._raidVc?.permissionOverwrites.edit(this._guild.roles.everyone.id, {
                         "CONNECT": null
+                    }),                    
+                    this._afkCheckChannel.send({
+                        content: `${this._raidVc?.toString()} has been unlocked!`
                     }),
-                    await i.reply({
+                    i.reply({
                         content: "Unlocked Raid VC.",
                         ephemeral: true
                     }),

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -2059,6 +2059,7 @@ export class RaidInstance {
         }
         const editMessage = this._afkCheckMsg.edit({
             embeds: [this.getAfkCheckEmbed()!],
+            components: AdvancedCollector.getActionRowsFromComponents(this._afkCheckButtons),
         })
 
         const delayUpdate = this.delay(this._intervalDelay);

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -2018,7 +2018,7 @@ export class RaidInstance {
          * stop intervals and return
          */
          if(Date.now() > this._expTime){
-            this._logger.info(`${this._instanceInfo} Headcount expired, aborting`);
+            this._logger.info(`${this._instanceInfo} Raid expired, aborting`);
             this.cleanUpRaid(true).then();
             return true;
         }

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -1857,7 +1857,7 @@ export class RaidInstance {
             .setTitle(`**${this._dungeon.dungeonName}** Raid.`)
             .setFooter({
                 text: `${this._memberInit.guild.name} ⇨ ${this._raidSection.sectionName} Control Panel.  Expires in `
-                        + `${Math.trunc((this._expTime-Date.now())/(1000*60))} minutes.`
+                        + `${TimeUtilities.formatDuration(this._expTime-Date.now(), false, false)}.`
             })
             .setTimestamp()
             .setColor(this._embedColor)

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -1,6 +1,6 @@
 // Suppress unused methods for this file.
 // noinspection JSUnusedGlobalSymbols,AssignmentToFunctionParameterJS
-
+import {Logger} from "../utilities/Logger";
 import {AdvancedCollector} from "../utilities/collectors/AdvancedCollector";
 import {
     Collection,
@@ -67,6 +67,7 @@ const FOOTER_INFO_MSG: string = "If you don't want to log this run, press the \"
  * This class represents a raid.
  */
 export class RaidInstance {
+    private _logger: Logger;   
     /**
      * A collection of active AFK checks and raids. The key is the AFK check message ID and the value is the raid
      * manager object.
@@ -251,6 +252,9 @@ export class RaidInstance {
      */
     private constructor(memberInit: GuildMember, guildDoc: IGuildInfo, section: ISectionInfo,
                         dungeon: IDungeonInfo | ICustomDungeonInfo, raidOptions?: IRaidOptions) {
+        this._logger = new Logger(__filename);
+        this._logger.setDebugOutput(false);
+
         this._memberInit = memberInit;
         this._guild = memberInit.guild;
         this._dungeon = dungeon;
@@ -1653,6 +1657,7 @@ export class RaidInstance {
      * @private
      */
     public getAfkCheckEmbed(): MessageEmbed | null {
+        this._logger.debug("Getting afk message embed: " + this._leaderName + ", " + this._dungeon.dungeonName);
         if (!this._raidVc) return null;
         if (this._raidStatus === RaidStatus.NOTHING || this._raidStatus === RaidStatus.IN_RUN) return null;
 
@@ -1769,6 +1774,7 @@ export class RaidInstance {
      * @private
      */
     public getControlPanelEmbed(): MessageEmbed | null {
+        this._logger.debug("Getting afk control panel embed: " + this._leaderName + ", " + this._dungeon.dungeonName);
         if (!this._raidVc) return null;
         if (this._raidStatus === RaidStatus.NOTHING) return null;
 

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -314,8 +314,8 @@ export class RaidInstance {
         );
         this._instanceInfo = `[${this._leaderName}, ${this._dungeon.dungeonName}]`
         this._logger.info(`${this._instanceInfo} Raid constructed`);
-        this._logger.debug(`${this._instanceInfo} Raid start time: ${TimeUtilities.getDateTime(this._startTime, "America/New_York")}`);
-        this._logger.debug(`${this._instanceInfo} Raid expiration time: ${TimeUtilities.getDateTime(this._expTime, "America/New_York")}`);
+        this._logger.debug(`${this._instanceInfo} Raid start time: ${TimeUtilities.getDateTime(this._startTime, "America/Los_Angeles")}`);
+        this._logger.debug(`${this._instanceInfo} Raid expiration time: ${TimeUtilities.getDateTime(this._expTime, "America/Los_Angeles")}`);
 
         // Which essential reacts are we going to use.
         const reactions = getReactions(dungeon, guildDoc);

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -1217,7 +1217,7 @@ export class RaidInstance {
      * @private
      */
     private async updateLocation(newLoc: string): Promise<boolean> {
-        this._logger.info(`${this._instanceInfo} Updating location of raid to ${newLoc}}`)
+        this._logger.info(`${this._instanceInfo} Updating location of raid to ${newLoc}}`);
         if (!this._raidVc || !this._addedToDb)
             return false;
 
@@ -1342,7 +1342,7 @@ export class RaidInstance {
      * @private
      */
     private sendMsgToEarlyLocationPeople(msgOpt: MessageOptions): void {
-        this._logger.info(`${this._instanceInfo} Sending message to early location receivers: ${msgOpt.content}`)
+        this._logger.info(`${this._instanceInfo} Sending message to early location receivers: ${msgOpt.content}`);
         const sentMsgTo: string[] = [];
         for (const [, members] of this._pplWithEarlyLoc) {
             members.forEach(async obj => {
@@ -1517,7 +1517,7 @@ export class RaidInstance {
      * of the raid is deleted.
      */
     public async cleanUpRaid(force: boolean): Promise<void> {
-        this._logger.info(`${this._instanceInfo} Cleaning up raid`)
+        this._logger.info(`${this._instanceInfo} Cleaning up raid`);
         this.stopAllIntervalsAndCollectors();
         // Step 1: Remove from ActiveRaids collection
         if (this._afkCheckMsg) {
@@ -1645,7 +1645,7 @@ export class RaidInstance {
      * @returns {Promise<boolean>} True if the bot was able to ask for a new location (regardless of the response).
      */
     public async getNewLocation(requestedAuthor: User): Promise<boolean> {
-        this._logger.info(`${this._instanceInfo} Requesting new location`)
+        this._logger.info(`${this._instanceInfo} Requesting new location`);
         if (!this._raidVc)
             return false;
         const descSb = new StringBuilder()
@@ -1693,7 +1693,7 @@ export class RaidInstance {
                 .append(`the raid location. Your new location is: **${this._location}**.`)
                 .toString()
         });
-        this._logger.info(`${this._instanceInfo} Location change successful`)
+        this._logger.info(`${this._instanceInfo} Location change successful`);
         return true;
     }
 
@@ -2106,10 +2106,10 @@ export class RaidInstance {
             const reactInfo = this._allEssentialOptions.get(mapKey)!;
             const members = this._pplWithEarlyLoc.get(mapKey)!;
 
-            this._logger.info(`${this._instanceInfo} Collected reaction from ${memberThatResponded.displayName}`)
+            this._logger.info(`${this._instanceInfo} Collected reaction from ${memberThatResponded.displayName}`);
             // If the member already got this, then don't let them get this again.
             if (members.some(x => x.member.id === i.user.id)) {
-                this._logger.info(`${this._instanceInfo} Reaction was already accounted for`)
+                this._logger.info(`${this._instanceInfo} Reaction was already accounted for`);
                 i.reply({
                     content: "You have already selected this!",
                     ephemeral: true
@@ -2121,7 +2121,7 @@ export class RaidInstance {
             const itemDis = getItemDisplay(reactInfo);
             // If we no longer need this anymore, then notify them
             if (!this.stillNeedEssentialReact(mapKey)) {
-                this._logger.info(`${this._instanceInfo} Reaction no longer essential, person not moved`)
+                this._logger.info(`${this._instanceInfo} Reaction no longer essential, person not moved`);
                 i.reply({
                     content: `Sorry, but the maximum number of ${itemDis} has been reached.`,
                     ephemeral: true
@@ -2139,7 +2139,7 @@ export class RaidInstance {
             );
 
             if (!this._raidVc) {
-                this._logger.info(`${this._instanceInfo} Raid closed during reaction`)
+                this._logger.info(`${this._instanceInfo} Raid closed during reaction`);
                 if (res.success || res.errorReply.alreadyReplied) {
                     await i.editReply({
                         content: "The raid you are attempting to react to has been closed or aborted.",
@@ -2175,7 +2175,7 @@ export class RaidInstance {
 
             // Make sure we can actually give early location. It might have changed.
             if (!this.stillNeedEssentialReact(mapKey)) {
-                this._logger.info(`${this._instanceInfo} Reaction no longer essential, person not moved`)
+                this._logger.info(`${this._instanceInfo} Reaction no longer essential, person not moved`);
                 await i.editReply({
                     content: reactInfo.type === "EARLY_LOCATION"
                         ? "Although you reacted with this button, you are not able to receive early location"
@@ -2194,11 +2194,11 @@ export class RaidInstance {
 
             // If we no longer need this, then edit the button so no one else can click on it.
             if (!this.stillNeedEssentialReact(mapKey)) {
-                this._logger.info(`${this._instanceInfo} Reaction no longer essential, disabling button`)
+                this._logger.info(`${this._instanceInfo} Reaction no longer essential, disabling button`);
                 const idxOfButton = this._afkCheckButtons.findIndex(x => x.customId === mapKey);
                 this._afkCheckButtons[idxOfButton].setDisabled(true);
             }
-            this._logger.info(`${this._instanceInfo} Reaction confirmed`)
+            this._logger.info(`${this._instanceInfo} Reaction confirmed`);
             const confirmationContent = new StringBuilder()
                 .append(`Thank you for confirming your choice of: `).append(itemDis)
                 .appendLine(2)
@@ -2234,7 +2234,7 @@ export class RaidInstance {
             if (memberThatResponded.voice.channel) {
                 if (memberThatResponded.voice.channelId === this._raidVc.id)
                     return;
-                this._logger.info(`${this._instanceInfo} Moving ${memberThatResponded.displayName} into raid VC`)
+                this._logger.info(`${this._instanceInfo} Moving ${memberThatResponded.displayName} into raid VC`);
                 memberThatResponded.voice.setChannel(this._raidVc).catch();
                 return;
             }

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -1402,7 +1402,7 @@ export class RaidInstance {
         }
 
         for (const field of ArrayUtilities.breakArrayIntoSubsets(inVcNotInRaidFields, 70)) {
-            embed.addField("In Raid VC, Not In /who.", StringUtil.codifyString(field.join(", ")));
+            embed.addField("In Raid VC, Not In /who.", field.join(", "));
         }
 
         return embed;
@@ -1448,7 +1448,7 @@ export class RaidInstance {
                 .map(x => x.toLowerCase());
             const idx = parsedNames.findIndex(name => igns.includes(name.toLowerCase()));
             if (idx === -1) return;
-            toReturn.inVcButNotInRaid.push(member);
+            toReturn.inVcButNotInRaid.push(member.displayName);
         });
 
         // Get people in raid but not in the VC. Could be crashers.
@@ -3068,7 +3068,7 @@ enum RaidStatus {
 }
 
 interface IParseResponse {
-    inVcButNotInRaid: GuildMember[];
+    inVcButNotInRaid: string[];
     inRaidButNotInVC: string[];
     isValid: boolean;
 }

--- a/src/managers/ModmailManager.ts
+++ b/src/managers/ModmailManager.ts
@@ -19,8 +19,11 @@ import {EmojiConstants} from "../constants/EmojiConstants";
 import {AdvancedCollector} from "../utilities/collectors/AdvancedCollector";
 import {ButtonConstants} from "../constants/ButtonConstants";
 import {StringUtil} from "../utilities/StringUtilities";
+import {Logger} from "../utilities/Logger";
 
 export namespace ModmailManager {
+
+    const _logger = new Logger(__filename, false);
     /**
      * Checks whether the original message satisfies the preconditions for a modmail message. The preconditions are:
      * - The original message's channel must be a `TextChannel`.
@@ -319,10 +322,6 @@ export namespace ModmailManager {
 
         if (guildsToChoose.length === 0) {
             return null;
-        }
-
-        if (guildsToChoose.length === 1) {
-            return guildsToChoose[0];
         }
 
         const uniqueId = StringUtil.generateRandomString(20);

--- a/src/managers/ModmailManager.ts
+++ b/src/managers/ModmailManager.ts
@@ -21,9 +21,9 @@ import {ButtonConstants} from "../constants/ButtonConstants";
 import {StringUtil} from "../utilities/StringUtilities";
 import {Logger} from "../utilities/Logger";
 
+const LOGGER: Logger = new Logger(__filename, false);
 export namespace ModmailManager {
 
-    const _logger = new Logger(__filename, false);
     /**
      * Checks whether the original message satisfies the preconditions for a modmail message. The preconditions are:
      * - The original message's channel must be a `TextChannel`.

--- a/src/managers/PunishmentManager.ts
+++ b/src/managers/PunishmentManager.ts
@@ -10,6 +10,7 @@ import {Filter} from "mongodb";
 import {Queue} from "../utilities/Queue";
 import {TimeUtilities} from "../utilities/TimeUtilities";
 import {MessageUtilities} from "../utilities/MessageUtilities";
+import {Logger} from "../utilities/Logger";
 
 interface IPunishmentCommandResult {
     /**
@@ -192,6 +193,7 @@ interface IAdditionalPunishmentParams {
 const AUTOMATIC: string = "Automatic";
 
 export namespace PunishmentManager {
+    const _logger = new Logger(__filename, false);
     /**
      * Acknowledges a punishment. Sends the appropriate log message to the logging channel, sends a message to the
      * user, and saves the punishment information into the user's document. You will need to handle the punishment
@@ -207,6 +209,9 @@ export namespace PunishmentManager {
         punishmentType: AllModLogType,
         details: IPunishmentDetails
     ): Promise<string | null> {
+        
+        _logger.info(`Logging punishment for ${"name" in member ? member.name : member.displayName}, type: ${punishmentType}`);
+
         let logChannel: TextChannel | null;
         let resolvedModType: MainOnlyModLogType | SectionModLogType | null;
 
@@ -697,6 +702,10 @@ export namespace SuspensionManager {
     const _queuedDelSectionSuspendedMembers = new Queue<ISuspendedUser & { guildId: string; sectionId: string; }>();
     const _queuedDelSectionIds = new Queue<{ guildId: string; sectionId: string; }>();
 
+    // Time between each checker
+    const timeToUpdate: number = 60*1000;
+
+    const _logger = new Logger(__filename, true);
 
     let _isRunning = false;
 
@@ -708,6 +717,7 @@ export namespace SuspensionManager {
     export async function startChecker(documents: IGuildInfo[] = []): Promise<void> {
         if (_isRunning) return;
         _isRunning = true;
+        _logger.info("Starting SuspensionManager checker");
 
         if (documents.length > 0) {
             for await (const guildDoc of documents) {
@@ -746,6 +756,7 @@ export namespace SuspensionManager {
      */
     export function stopChecker(): void {
         if (!_isRunning) return;
+        _logger.info("Stopping SuspensionManager checker");
         _isRunning = false;
     }
 
@@ -755,7 +766,7 @@ export namespace SuspensionManager {
      */
     async function suspensionChecker(): Promise<void> {
         if (!_isRunning) return;
-
+        _logger.info("Running SuspensionManager checker");
         // Remove all elements before checking.
         while (_queuedDelSuspendedMembers.size() > 0) {
             const dequeuedElem = _queuedDelSuspendedMembers.dequeue();
@@ -877,8 +888,9 @@ export namespace SuspensionManager {
             }
         }
 
+        _logger.info("SuspensionManager finished");
         // Now, wait one minute before trying again.
-        setTimeout(suspensionChecker, 60 * 1000);
+        setTimeout(suspensionChecker, timeToUpdate);
     }
 
     /**
@@ -895,6 +907,8 @@ export namespace SuspensionManager {
         mod: GuildMember | null,
         info: Omit<IAdditionalPunishmentParams, "actionId" | "section">
     ): Promise<IPunishmentCommandResult> {
+
+        _logger.info(`${mod?.displayName} is suspending ${member.displayName}`);
         // If the person was already suspended, then we don't need to re-suspend the person.
         if (GuildFgrUtilities.memberHasCachedRole(member, info.guildDoc.roles.suspendedRoleId)
             || info.guildDoc.moderation.suspendedUsers.some(x => x.affectedUser.id === member.id))
@@ -987,6 +1001,7 @@ export namespace SuspensionManager {
         mod: GuildMember | null,
         info: Omit<IAdditionalPunishmentParams, "section" | "duration">
     ): Promise<IPunishmentCommandResult> {
+        _logger.info(`${mod ? mod.displayName : `Bot`} is removing suspension for ${member.displayName}`);
         // Find suspension info.
         const memberLookup: ISuspendedUser | null = info.actionId
             ? lookupSuspension(info.guildDoc, null, {actionId: info.actionId})
@@ -1062,6 +1077,7 @@ export namespace SuspensionManager {
         mod: GuildMember | null,
         info: IAdditionalPunishmentParams
     ): Promise<IPunishmentCommandResult> {
+        _logger.info(`${mod ? mod.displayName : `Bot`} is section suspending ${member.displayName}`);
         // If the person was already suspended, then we don't need to re-suspend the person.
         if (info.section.moderation.sectionSuspended.some(x => x.affectedUser.id === member.id))
             return {punishmentResolved: false, punishmentLogged: false, moderationId: null};
@@ -1138,6 +1154,7 @@ export namespace SuspensionManager {
         mod: GuildMember | null,
         info: Omit<IAdditionalPunishmentParams, "duration">
     ): Promise<IPunishmentCommandResult> {
+        _logger.info(`${mod ? mod.displayName : `Bot`} is removing section suspension for ${member.displayName}`);
         // Find suspension info.
         const memberLookup: ISuspendedUser | null = info.actionId
             ? lookupSuspension(info.guildDoc, info.section, {actionId: info.actionId})
@@ -1202,6 +1219,7 @@ export namespace SuspensionManager {
         memberId?: string;
         actionId?: string;
     }): ISuspendedUser | null {
+        _logger.info(`Looking up suspension`);
         if (!lookupType.memberId && !lookupType.actionId)
             return null;
 
@@ -1240,6 +1258,10 @@ export namespace SuspensionManager {
 export namespace MuteManager {
     export const MutedMembers = new Collection<string, IMutedUser[]>();
     const _queuedDelMutedUsers = new Queue<IMutedUser & { guildId: string; }>();
+    const _logger = new Logger(__filename, false);
+
+    // Time between each checker
+    const timeToUpdate: number = 60*1000;
 
     let _isRunning = false;
 
@@ -1251,7 +1273,7 @@ export namespace MuteManager {
     export async function startChecker(documents: IGuildInfo[] = []): Promise<void> {
         if (_isRunning) return;
         _isRunning = true;
-
+        _logger.info("Starting MuteManager checker");
         if (documents.length > 0) {
             for await (const guildDoc of documents) {
                 const serverSus = new Collection<string, IMutedUser[]>();
@@ -1272,6 +1294,7 @@ export namespace MuteManager {
      */
     export function stopChecker(): void {
         if (!_isRunning) return;
+        _logger.info("Stopping MuteManager checker");
         _isRunning = false;
     }
 
@@ -1281,6 +1304,7 @@ export namespace MuteManager {
      */
     async function muteChecker(): Promise<void> {
         if (!_isRunning) return;
+        _logger.info("Running MuteManager checker");
         // Remove all users that were already queued for unmuting from checker
         while (_queuedDelMutedUsers.size() > 0) {
             const dequeuedElem = _queuedDelMutedUsers.dequeue();
@@ -1326,8 +1350,8 @@ export namespace MuteManager {
                 });
             }
         }
-
-        setTimeout(muteChecker, 60 * 1000);
+        _logger.info("MuteManager finished");
+        setTimeout(muteChecker, timeToUpdate);
     }
 
     /**
@@ -1344,9 +1368,11 @@ export namespace MuteManager {
         mod: GuildMember | null,
         info: Omit<IAdditionalPunishmentParams, "actionId" | "section">
     ): Promise<IPunishmentCommandResult> {
+        _logger.info(`${mod ? mod.displayName : `Bot`} is adding mute for ${member.displayName}`);
         // Create the role if it doesn't already exist.
         let mutedRole = await GuildFgrUtilities.fetchRole(member.guild, info.guildDoc.roles.mutedRoleId);
         if (!mutedRole) {
+            _logger.info(`Muted role does not exist, creating role`);
             mutedRole = await member.guild.roles.create({
                 name: "Muted",
                 permissions: []
@@ -1446,6 +1472,7 @@ export namespace MuteManager {
         mod: GuildMember | null,
         info: Omit<IAdditionalPunishmentParams, "section" | "duration">
     ): Promise<IPunishmentCommandResult> {
+        _logger.info(`${mod ? mod.displayName : `Bot`} is removing mute for ${member.displayName}`);
         if (!GuildFgrUtilities.hasCachedRole(member.guild, info.guildDoc.roles.mutedRoleId))
             return {punishmentResolved: false, punishmentLogged: false, moderationId: null};
 
@@ -1499,6 +1526,7 @@ export namespace MuteManager {
      */
     export async function removeAllMuteInGuild(guild: Guild, mod: GuildMember | null,
                                                reason?: string): Promise<boolean> {
+        _logger.info(`${mod ? mod.displayName : `Bot`} is removing all mutes for the server`);
         MutedMembers.get(guild.id)?.forEach(x => {
             _queuedDelMutedUsers.enqueue({...x, guildId: guild.id});
         });
@@ -1544,6 +1572,7 @@ export namespace MuteManager {
         memberId?: string;
         actionId?: string;
     }): IMutedUser | null {
+        _logger.info(`Looking up mute`);
         if (!lookupType.memberId && !lookupType.actionId)
             return null;
 

--- a/src/managers/PunishmentManager.ts
+++ b/src/managers/PunishmentManager.ts
@@ -766,7 +766,7 @@ export namespace SuspensionManager {
      */
     async function suspensionChecker(): Promise<void> {
         if (!_isRunning) return;
-        _logger.info("Running SuspensionManager checker");
+        _logger.debug("Running SuspensionManager checker");
         // Remove all elements before checking.
         while (_queuedDelSuspendedMembers.size() > 0) {
             const dequeuedElem = _queuedDelSuspendedMembers.dequeue();
@@ -888,7 +888,7 @@ export namespace SuspensionManager {
             }
         }
 
-        _logger.info("SuspensionManager finished");
+        _logger.debug("SuspensionManager finished");
         // Now, wait one minute before trying again.
         setTimeout(suspensionChecker, timeToUpdate);
     }
@@ -1304,7 +1304,7 @@ export namespace MuteManager {
      */
     async function muteChecker(): Promise<void> {
         if (!_isRunning) return;
-        _logger.info("Running MuteManager checker");
+        _logger.debug("Running MuteManager checker");
         // Remove all users that were already queued for unmuting from checker
         while (_queuedDelMutedUsers.size() > 0) {
             const dequeuedElem = _queuedDelMutedUsers.dequeue();
@@ -1350,7 +1350,7 @@ export namespace MuteManager {
                 });
             }
         }
-        _logger.info("MuteManager finished");
+        _logger.debug("MuteManager finished");
         setTimeout(muteChecker, timeToUpdate);
     }
 

--- a/src/managers/PunishmentManager.ts
+++ b/src/managers/PunishmentManager.ts
@@ -705,7 +705,7 @@ export namespace SuspensionManager {
     // Time between each checker
     const timeToUpdate: number = 60*1000;
 
-    const _logger = new Logger(__filename, true);
+    const _logger = new Logger(__filename, false);
 
     let _isRunning = false;
 

--- a/src/managers/PunishmentManager.ts
+++ b/src/managers/PunishmentManager.ts
@@ -301,7 +301,7 @@ export namespace PunishmentManager {
             .toString();
 
         const durationStr = new StringBuilder()
-            .append(`- Duration: ${entry.duration! === -1 ? "N/A" : TimeUtilities.formatDuration(entry.duration!)}`)
+            .append(`- Duration: ${entry.duration! === -1 ? "N/A" : TimeUtilities.formatDuration(entry.duration!, true, false)}`)
             .appendLine()
             .append(`- Ends At: ${entry.expiresAt! === -1 ? "N/A" : `${TimeUtilities.getDateTime(entry.expiresAt!)} GMT`}`)
             .toString();

--- a/src/managers/QuotaManager.ts
+++ b/src/managers/QuotaManager.ts
@@ -635,6 +635,7 @@ export namespace QuotaManager {
         );
         const timeLeft = TimeUtilities.formatDuration(endTime.getTime() - Date.now(), false);
 
+        const MILL_TO_MIN = 1000*60;
         const quotaPtDisplay = getPointListAsString(guildDoc, quotaInfo);
         const embed = MessageUtilities.generateBlankEmbed(guild, "RANDOM")
             .setTitle(`Active Quota: ${role.name}`)
@@ -657,7 +658,7 @@ export namespace QuotaManager {
                     .toString()
             )
             .setTimestamp()
-            .setFooter({text: "Leaderboard Updated Every 30 Seconds. Last Updated:"});
+            .setFooter({text: `Leaderboard updated every ${QuotaService.timeToUpdate/MILL_TO_MIN} minute${QuotaService.timeToUpdate!==MILL_TO_MIN ? `s` : ``}. Last Updated:`});
 
         if (quotaInfo.quotaLog.length === 0)
             return embed;
@@ -707,7 +708,7 @@ export namespace QuotaManager {
 // Service that updates quota leaderboards every 5 minutes
 export namespace QuotaService {
     const _logger: Logger = new Logger(__filename, false);
-    const timeToUpdate: number = 5*60*1000;
+    export const timeToUpdate: number = 3*60*1000;
 
     let _isRunning = false;
 

--- a/src/managers/QuotaManager.ts
+++ b/src/managers/QuotaManager.ts
@@ -806,7 +806,7 @@ export namespace QuotaService {
                 });
             }
         }
-        _logger.info("Quota service finished.");
+        _logger.debug("Quota service finished.");
         setTimeout(run, timeToUpdate);
     }
 }

--- a/src/managers/QuotaManager.ts
+++ b/src/managers/QuotaManager.ts
@@ -288,7 +288,7 @@ export namespace QuotaManager {
             guildDoc.quotas.resetTime.dayOfWeek,
             guildDoc.quotas.resetTime.time
         );
-        const timeLeft = TimeUtilities.formatDuration(endTime.getTime() - startTime.getTime());
+        const timeLeft = TimeUtilities.formatDuration(endTime.getTime() - startTime.getTime(), true);
 
         if (role) {
             oldQuotas.quotaLog = [];
@@ -633,7 +633,7 @@ export namespace QuotaManager {
             guildDoc.quotas.resetTime.dayOfWeek,
             guildDoc.quotas.resetTime.time
         );
-        const timeLeft = TimeUtilities.formatDuration(endTime.getTime() - Date.now(), false);
+        const timeLeft = TimeUtilities.formatDuration(endTime.getTime() - Date.now(), true, false);
 
         const MILL_TO_MIN = 1000*60;
         const quotaPtDisplay = getPointListAsString(guildDoc, quotaInfo);

--- a/src/managers/QuotaManager.ts
+++ b/src/managers/QuotaManager.ts
@@ -51,7 +51,7 @@ export namespace QuotaManager {
         "NameAdjustment"
     ];
 
-    const _logger: Logger = new Logger(__filename, true);
+    const _logger: Logger = new Logger(__filename, false);
     /**
      * Checks if the string is of some quota type.
      * @param {string} str The string to test.

--- a/src/managers/QuotaManager.ts
+++ b/src/managers/QuotaManager.ts
@@ -26,6 +26,7 @@ import {StringUtil} from "../utilities/StringUtilities";
 import {GeneralConstants} from "../constants/GeneralConstants";
 import {DungeonUtilities} from "../utilities/DungeonUtilities";
 import {EmojiConstants} from "../constants/EmojiConstants";
+import {Logger} from "../utilities/Logger";
 
 export namespace QuotaManager {
     export const ALL_QUOTAS_KV: { [key: string]: string } = {
@@ -50,6 +51,7 @@ export namespace QuotaManager {
         "NameAdjustment"
     ];
 
+    const _logger: Logger = new Logger(__filename, true);
     /**
      * Checks if the string is of some quota type.
      * @param {string} str The string to test.
@@ -77,6 +79,8 @@ export namespace QuotaManager {
      * @returns {Promise<boolean>} Whether this was successful.
      */
     export async function resetQuota(guild: Guild, roleId: string): Promise<boolean> {
+        _logger.info(`Resetting quota for roleid ${roleId}`);
+
         const guildDoc = await MongoManager.getOrCreateGuildDoc(guild, true);
         if (!guildDoc)
             return false;
@@ -324,6 +328,7 @@ export namespace QuotaManager {
      * @param {Guild} guild The guild.
      */
     export async function resetAllQuota(guild: Guild): Promise<void> {
+        _logger.info(`Resetting all quotas for guild ${guild.name}`);
         const doc = await MongoManager.getOrCreateGuildDoc(guild.id, true);
         await Promise.all(doc.quotas.quotaInfo.map(async x => resetQuota(guild, x.roleId)));
     }
@@ -346,6 +351,7 @@ export namespace QuotaManager {
      */
     export function findBestQuotaToAdd(member: GuildMember, guildDoc: IGuildInfo, logType: QuotaLogType,
                                        dungeonId?: string): string | null {
+        _logger.info(`Finding best quota to add ${logType} for ${member.displayName}`);
         let resolvedLogType: string = logType;
         if (logType === "RunAssist" || logType === "RunComplete" || logType === "RunFailed") {
             if (!dungeonId) return null;
@@ -360,10 +366,13 @@ export namespace QuotaManager {
                 // - Run_____                       For all dungeons (i.e. no ID specifier).
                 && (x.pointValues.find(y => y.key === resolvedLogType || y.key === logType)?.value ?? 0) > 0;
         });
+        _logger.debug(`Available quotas for ${resolvedLogType}: ${availableQuotas.toLocaleString()}`);
 
         if (availableQuotas.length === 0)
             return null;
 
+        /**TODO: Remove duplicate roles for same section type (Oryx Leader should ignore AlmostOryxLeader) */
+        _logger.debug(`ADDRESS THIS TODO`);
         const quotaData: QuotaMemberInfo[] = availableQuotas.map(x => {
             const curPts = calcTotalQuotaPtsForMember(member.id, x.roleId, guildDoc);
             return {
@@ -375,6 +384,7 @@ export namespace QuotaManager {
         });
 
         quotaData.sort((a, b) => a.percentComplete - b.percentComplete);
+        _logger.debug(`Selected ${quotaData[0].roleId}`);
         return quotaData[0].roleId;
     }
 
@@ -387,6 +397,7 @@ export namespace QuotaManager {
      */
     export async function logQuota(member: GuildMember, roleId: string, logType: string,
                                    amt: number): Promise<void> {
+        _logger.info(`Logging quota for ${member.displayName}, role: ${roleId}, type: ${logType}, amount: ${amt}`);
         await MongoManager.updateAndFetchGuildDoc({
             guildId: member.guild.id,
             "quotas.quotaInfo.roleId": roleId
@@ -611,6 +622,7 @@ export namespace QuotaManager {
      */
     export async function getQuotaLeaderboardEmbed(guild: Guild, guildDoc: IGuildInfo,
                                                    quotaInfo: IQuotaInfo): Promise<MessageEmbed | null> {
+        _logger.debug(`Getting Quota Leaderboard Embed: ${quotaInfo.roleId}`);
         const role = GuildFgrUtilities.getCachedRole(guild, quotaInfo.roleId);
         if (!role)
             return null;
@@ -694,6 +706,9 @@ export namespace QuotaManager {
 
 // Service that updates quota leaderboards every 5 minutes
 export namespace QuotaService {
+    const _logger: Logger = new Logger(__filename, false);
+    const timeToUpdate: number = 5*60*1000;
+
     let _isRunning = false;
 
     /**
@@ -701,7 +716,7 @@ export namespace QuotaService {
      */
     export async function startService(): Promise<void> {
         if (_isRunning) return;
-
+        _logger.info("Starting Quota Service");
         const docs = await MongoManager.getGuildCollection().find().toArray();
         if (docs.length > 0) {
             const allQuotasToReset: Promise<boolean>[] = [];
@@ -734,15 +749,17 @@ export namespace QuotaService {
      * Stops the quota service.
      */
     export function stopService(): void {
+        _logger.info("Stopping Quota Service");
         if (!_isRunning) return;
         _isRunning = false;
     }
 
     /**
-     * Runs tbe quota service once. This updates all active quotas across all guilds.
+     * Runs the quota service once. This updates all active quotas across all guilds.
      * @private
      */
     async function run(): Promise<void> {
+        _logger.info("Running quota service to update quotas.");
         const allGuildDocs = await MongoManager.getGuildCollection().find().toArray();
         for await (const guildDoc of allGuildDocs) {
             if (guildDoc.quotas.quotaInfo.length === 0)
@@ -788,7 +805,7 @@ export namespace QuotaService {
                 });
             }
         }
-
-        setTimeout(run, 30 * 1000);
+        _logger.info("Quota service finished.");
+        setTimeout(run, timeToUpdate);
     }
 }

--- a/src/utilities/Logger.ts
+++ b/src/utilities/Logger.ts
@@ -11,11 +11,12 @@ export class Logger {
     /**
      * Creates a new `Logger` object.
      * @param {string} filePath The file using the logger. Use `__filename`.
+     * @param {boolean} debug Whether to output DEBUG messages, default = false
      */
-    public constructor(fileName: string) {
+    public constructor(fileName: string, debug = false) {
         this.path = require("path").basename(fileName);
         this.formattedPath = `[${this.path}]`;
-        this.outputDebug = false;
+        this.outputDebug = debug;
     }
 
     /**

--- a/src/utilities/Logger.ts
+++ b/src/utilities/Logger.ts
@@ -31,33 +31,33 @@ export class Logger {
      * Logs information to console with time and file information
      * @param {*} s the message to log to the console
      */
-    public info(s: any): void {
-        console.info("[INFO]", Logger.getCurrentTime(), this.formattedPath, s);
+    public info(...args: any[]): void {
+        console.info("[INFO]", Logger.getCurrentTime(), this.formattedPath, args);
     }
 
     /**
      * Logs debug information to the console with the time and file information.
      * @param {*} s the message to log to the console.
      */
-     public debug(s: any): void {
+     public debug(...args: any[]): void {
         if(!this.outputDebug) return;
-        console.debug("[DEBUG]", Logger.getCurrentTime(), this.formattedPath, s);
+        console.debug("[DEBUG]", Logger.getCurrentTime(), this.formattedPath, args);
     }
 
     /**
      * Logs a warning to the console with the time and file information.
      * @param {*} s the message to log to the console.
      */
-    public warn(s: any): void {
-        console.warn("[WARN]", Logger.getCurrentTime(), this.formattedPath, s);
+    public warn(...args: any[]): void {
+        console.warn("[WARN]", Logger.getCurrentTime(), this.formattedPath, args);
     }
 
     /**
      * Logs error message to console with time and file information
      * @param {*} s the error message to log to the console
      */
-    public error(s: any): void {
-        console.error("[ERROR]", Logger.getCurrentTime(), this.formattedPath, s);
+    public error(...args: any[]): void {
+        console.error("[ERROR]", Logger.getCurrentTime(), this.formattedPath, args);
     }
 
     /**

--- a/src/utilities/Logger.ts
+++ b/src/utilities/Logger.ts
@@ -24,7 +24,7 @@ export class Logger {
      * @returns The current time, formatted to EST.
      */
     private static getCurrentTime(): string {
-        return `[${TimeUtilities.getDateTime(Date.now(), "America/New_York")}]`;
+        return `[${TimeUtilities.getDateTime(Date.now(), "America/Los_Angeles")}]`;
     }
 
     /**

--- a/src/utilities/Logger.ts
+++ b/src/utilities/Logger.ts
@@ -20,10 +20,10 @@ export class Logger {
 
     /**
      * Gets the current time.
-     * @returns The current time, formatted.
+     * @returns The current time, formatted to EST.
      */
     private static getCurrentTime(): string {
-        return `[${TimeUtilities.getDateTime(Date.now(), "America/Los_Angeles")}]`;
+        return `[${TimeUtilities.getDateTime(Date.now(), "America/New_York")}]`;
     }
 
     /**

--- a/src/utilities/Logger.ts
+++ b/src/utilities/Logger.ts
@@ -32,7 +32,7 @@ export class Logger {
      * @param {*} s the message to log to the console
      */
     public info(s: any): void {
-        console.info("[INFO]", this.formattedPath, Logger.getCurrentTime(), s);
+        console.info("[INFO]", Logger.getCurrentTime(), this.formattedPath, s);
     }
 
     /**
@@ -40,7 +40,7 @@ export class Logger {
      * @param {*} s the message to log to the console.
      */
      public debug(s: any): void {
-        console.warn("[DEBUG]", this.formattedPath, Logger.getCurrentTime(), s);
+        console.warn("[DEBUG]", Logger.getCurrentTime(), this.formattedPath, s);
     }
 
     /**
@@ -48,7 +48,7 @@ export class Logger {
      * @param {*} s the message to log to the console.
      */
     public warn(s: any): void {
-        console.warn("[WARN]", this.formattedPath, Logger.getCurrentTime(), s);
+        console.warn("[WARN]", Logger.getCurrentTime(), this.formattedPath, s);
     }
 
     /**
@@ -56,7 +56,7 @@ export class Logger {
      * @param {*} s the error message to log to the console
      */
     public error(s: any): void {
-        console.error("[ERROR]", this.formattedPath, Logger.getCurrentTime(), s);
+        console.error("[ERROR]", Logger.getCurrentTime(), this.formattedPath, s);
     }
 
     /**

--- a/src/utilities/Logger.ts
+++ b/src/utilities/Logger.ts
@@ -40,7 +40,8 @@ export class Logger {
      * @param {*} s the message to log to the console.
      */
      public debug(s: any): void {
-        console.warn("[DEBUG]", Logger.getCurrentTime(), this.formattedPath, s);
+        if(!this.outputDebug) return;
+        console.debug("[DEBUG]", Logger.getCurrentTime(), this.formattedPath, s);
     }
 
     /**

--- a/src/utilities/Logger.ts
+++ b/src/utilities/Logger.ts
@@ -1,0 +1,35 @@
+import {TimeUtilities} from "./TimeUtilities";
+
+/**
+ * Custom Logger class
+ */
+export class Logger{
+    private path: String;
+    /**
+     * Creates a new `Logger` object
+     * @param {String} filePath The basename of the file using the logger.
+     */
+    public constructor(filePath: String){
+        this.path = filePath;
+    }
+
+    /**
+     * Logs information to console with time and file information
+     * @param {String} s the message to log to the console
+     */
+    public info(s: String){
+        const path = `[${this.path}]`
+        const date = `[${TimeUtilities.getDateTime(Date.now(), "America/Los_Angeles")}]`;        
+        console.info("[INFO]", path, date, s);
+    }
+
+    /**
+     * Logs error message to console with time and file information
+     * @param {String} s the error message to log to the console
+     */
+    public error(s: String){
+        const path = `[${this.path}]`
+        const date = `[${TimeUtilities.getDateTime(Date.now(), "America/Los_Angeles")}]`;        
+        console.info("[ERROR]", path, date, s);
+    }
+}

--- a/src/utilities/Logger.ts
+++ b/src/utilities/Logger.ts
@@ -63,6 +63,7 @@ export class Logger {
     /**
      * Decides if logger should output DEBUG messages or not
      * @param {*} bool true if DEBUG output desired, false otherwise
+     * @returns {void}
      */
     public setDebugOutput(bool: boolean){
         this.outputDebug = bool;

--- a/src/utilities/Logger.ts
+++ b/src/utilities/Logger.ts
@@ -1,35 +1,68 @@
-import {TimeUtilities} from "./TimeUtilities";
+import { TimeUtilities } from "./TimeUtilities";
 
 /**
  * Custom Logger class
  */
-export class Logger{
-    private path: String;
+export class Logger {
+    private path: string;
+    private formattedPath: string;
+    private outputDebug: boolean;
+
     /**
-     * Creates a new `Logger` object
-     * @param {String} filePath The basename of the file using the logger.
+     * Creates a new `Logger` object.
+     * @param {string} filePath The file using the logger. Use `__filename`.
      */
-    public constructor(filePath: String){
-        this.path = filePath;
+    public constructor(fileName: string) {
+        this.path = require("path").basename(fileName);
+        this.formattedPath = `[${this.path}]`;
+        this.outputDebug = false;
+    }
+
+    /**
+     * Gets the current time.
+     * @returns The current time, formatted.
+     */
+    private static getCurrentTime(): string {
+        return `[${TimeUtilities.getDateTime(Date.now(), "America/Los_Angeles")}]`;
     }
 
     /**
      * Logs information to console with time and file information
-     * @param {String} s the message to log to the console
+     * @param {*} s the message to log to the console
      */
-    public info(s: String){
-        const path = `[${this.path}]`
-        const date = `[${TimeUtilities.getDateTime(Date.now(), "America/Los_Angeles")}]`;        
-        console.info("[INFO]", path, date, s);
+    public info(s: any): void {
+        console.info("[INFO]", this.formattedPath, Logger.getCurrentTime(), s);
+    }
+
+    /**
+     * Logs debug information to the console with the time and file information.
+     * @param {*} s the message to log to the console.
+     */
+     public debug(s: any): void {
+        console.warn("[DEBUG]", this.formattedPath, Logger.getCurrentTime(), s);
+    }
+
+    /**
+     * Logs a warning to the console with the time and file information.
+     * @param {*} s the message to log to the console.
+     */
+    public warn(s: any): void {
+        console.warn("[WARN]", this.formattedPath, Logger.getCurrentTime(), s);
     }
 
     /**
      * Logs error message to console with time and file information
-     * @param {String} s the error message to log to the console
+     * @param {*} s the error message to log to the console
      */
-    public error(s: String){
-        const path = `[${this.path}]`
-        const date = `[${TimeUtilities.getDateTime(Date.now(), "America/Los_Angeles")}]`;        
-        console.info("[ERROR]", path, date, s);
+    public error(s: any): void {
+        console.error("[ERROR]", this.formattedPath, Logger.getCurrentTime(), s);
+    }
+
+    /**
+     * Decides if logger should output DEBUG messages or not
+     * @param {*} bool true if DEBUG output desired, false otherwise
+     */
+    public setDebugOutput(bool: boolean){
+        this.outputDebug = bool;
     }
 }

--- a/src/utilities/TimeUtilities.ts
+++ b/src/utilities/TimeUtilities.ts
@@ -59,7 +59,7 @@ export namespace TimeUtilities {
             validStr = true;
         }
 
-        return validStr ? {ms: duration, formatted: formatDuration(duration, false)} : null;
+        return validStr ? {ms: duration, formatted: formatDuration(duration, true, false)} : null;
     }
 
     /**
@@ -136,12 +136,12 @@ export namespace TimeUtilities {
     /**
      * Converts the specified non-negative duration to a formatted string.
      * @param {number} dur The non-negative duration, in milliseconds.
+     * @param {boolean} includeSeconds Whether to include the seconds portion in the formatted string.
      * @param {boolean} [includeMs] Whether to include the milliseconds portion in the formatted string.
      * @returns {string} The string representation of the duration.
-     * @throws {Error} When a negative number is given.
      */
-    export function formatDuration(dur: number, includeMs: boolean = true): string {
-        if (dur < 0) throw new Error("negative time");
+    export function formatDuration(dur: number, includeSeconds: boolean, includeMs: boolean = true): string {
+        dur = Math.max(0, dur);
 
         const days = Math.floor(dur / 8.64e+7);
         dur %= 8.64e+7;
@@ -156,7 +156,7 @@ export namespace TimeUtilities {
         if (days > 0) finalArr.push(`${days} Days`);
         if (hours > 0) finalArr.push(`${hours} Hours`);
         if (minutes > 0) finalArr.push(`${minutes} Minutes`);
-        if (seconds > 0) finalArr.push(`${seconds} Seconds`);
+        if (seconds > 0 && includeSeconds) finalArr.push(`${seconds} Seconds`);
         if (dur > 0 && includeMs) finalArr.push(`${dur} Milliseconds`);
         return finalArr.length > 0 ? finalArr.join(", ") : "0 Seconds";
     }


### PR DESCRIPTION
Changelog

1. Added Logger and used logging across many files
2. Added CleanVC command
3. Added logparse command
4. Headcount and AFK have timeout that applies even when bot is interrupted
5. Headcount control panels linger behind and keep reaction information (RE AvgPoptart)

[02-03-2022] VERSION: 1.0.1

6. Modmail must be confirmed even if user is part of one server
7. Warns ignore staff roll order
8. Intervals redesigned
9. Punishments now require duration.  Indefinite can be provided as "-1"
10. CleanVC does not clean staff
11. Raids announce when they are locked/unlocked, minor emoji changes
12. Poll appearance cleaned up, defaults to Yes/No

[02-03-2022] VERSION: 1.0.2'

13. Addressed comments after review: Logger, TimeUtilities